### PR TITLE
permit single quotes if they quote literal double quotes

### DIFF
--- a/R/single_quotes_linter.R
+++ b/R/single_quotes_linter.R
@@ -5,7 +5,7 @@ single_quotes_linter <- function(source_file) {
   lapply(ids_with_token(source_file, "STR_CONST"),
     function(id) {
       parsed <- with_id(source_file, id)
-      if (re_matches(parsed$text, rex(start, "'", anything, "'", end))) {
+      if (re_matches(parsed$text, rex(start, single_quote, any_non_double_quotes, single_quote, end))) {
         Lint(
           filename = source_file$filename,
           line_number = parsed$line1,

--- a/tests/testthat/test-single_quotes_linter.R
+++ b/tests/testthat/test-single_quotes_linter.R
@@ -12,6 +12,9 @@ test_that("returns the correct linting", {
 
   expect_lint("\"'blah'\"", NULL, single_quotes_linter)
 
+  expect_lint("'\"'", NULL, single_quotes_linter)
+  expect_lint("'\"blah\"'", NULL, single_quotes_linter)
+
   expect_lint("'blah'",
     rex("Only use double-quotes."),
     single_quotes_linter)


### PR DESCRIPTION
A legitimate use of a single quote pair in R is to quote a literal double quote. This tiny patch allows this. It's not immediately clear to me how to test a negative with your check_lint tests. Thanks.