### PR TITLE
Use RStudio source marker API to display lint items

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Imports:
     stringdist,
     testthat,
     digest,
-    igraph
+    igraph,
+    rstudioapi (>= 0.2)
 License: MIT + file LICENSE
 LazyData: true
 Suggests:

--- a/R/lint.R
+++ b/R/lint.R
@@ -118,6 +118,8 @@ lint_package <- function(path = NULL, relative_path = TRUE, ...) {
 
   lints <- reorder_lints(lints)
   class(lints) <- "lints"
+  attr(lints, "package_path") <- path
+  attr(lints, "relative_path") <- relative_path
   lints
 }
 
@@ -198,8 +200,43 @@ print.lint <- function(x, ...) {
 
 #' @export
 print.lints <- function(x, ...) {
-  lapply(x, print, ...)
+  if (getOption("lintr.rstudio_source_markers", TRUE) && 
+      rstudioapi::hasFun("sourceMarkers"))
+    rstudio_source_markers(x)
+  else
+    lapply(x, print, ...)
   invisible(x)
+}
+
+rstudio_source_markers <- function(lints) {
+  
+  # if relative paths were requested then save the package_path
+  # to be passed along as the basePath to the sourceMarker function
+  relative_path <- isTRUE(attr(lints, "relative_path"))
+  if (relative_path)
+    package_path <- attr(lints, "package_path")
+  else
+    package_path <- NULL
+  
+  # generate the markers
+  markers <- lapply(lints, function(x) {
+    marker <- list()
+    marker$type <- x$type
+    if (relative_path)
+      x$filename <- file.path(package_path, x$filename)
+    marker$file <- x$filename
+    marker$line <- x$line_number
+    marker$column <- x$column_number
+    marker$message <- x$message
+    marker
+  })
+  
+  # request source markers
+  rstudioapi::callFun("sourceMarkers", 
+                      name = "lintr", 
+                      markers = markers, 
+                      basePath = package_path,
+                      autoSelect = "first")
 }
 
 highlight_string <- function(message, column_number = NULL, ranges = NULL) {


### PR DESCRIPTION
When running under a version of RStudio that supports the source marker API display lints using the Markers pane (this behavior can be disabled via a global option). Note that this requires the most recent daily build of RStudio (v0.99.206) however will automatically degrade to the previous behavior when running any older version of RStudio. You can download the daily build here: http://www.rstudio.org/download/daily/desktop/