### PR TITLE
Disable linter for a specific line with # no-qa

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -70,7 +70,7 @@ lint <- function(filename, linters = default_linters, cache = FALSE) {
     save_cache(lint_cache, filename)
   }
 
-  ends_with_noqa <- function(s) grepl("# no-qa$", str_trim(s$line))
+  ends_with_noqa <- function(s) grepl("# no-qa$", s$line)
 
   lints <- Filter(ends_with_noqa, lints)
   lints

--- a/R/lint.R
+++ b/R/lint.R
@@ -70,7 +70,7 @@ lint <- function(filename, linters = default_linters, cache = FALSE) {
     save_cache(lint_cache, filename)
   }
 
-  ends_with_noqa <- function(s) grepl("# no-qa$", s$line)
+  ends_with_noqa <- function(s) !grepl("# no-qa$", s$line)
 
   lints <- Filter(ends_with_noqa, lints)
   lints

--- a/R/lint.R
+++ b/R/lint.R
@@ -70,6 +70,9 @@ lint <- function(filename, linters = default_linters, cache = FALSE) {
     save_cache(lint_cache, filename)
   }
 
+  ends_with_noqa <- function(s) grepl("# no-qa$", str_trim(s$line))
+
+  lints <- Filter(ends_with_noqa, lints)
   lints
 }
 


### PR DESCRIPTION
Sometimes you might want to keep the linter silent for some lines.
In [flake8](https://pypi.python.org/pypi/flake8) this is achieved by appending a ```# noqa``` comment to the offending line.
This PR adds this functionality to lintr.