### PR TITLE
Add linter for commented R code

### DIFF
--- a/R/commented_code_linter.R
+++ b/R/commented_code_linter.R
@@ -1,0 +1,29 @@
+#' @describeIn linters checks that there is no commented code outside roxygen
+#'   blocks
+#' @export
+commented_code_linter <- function(source_file) {
+  res <- re_matches(source_file$file_lines,
+                    rex("#", except("'"), anything,
+                        or(some_of("{}[]"), # code-like parentheses
+                           "<-", "->", "==", # an assignment
+                           group(graphs, "(", anything, ")"), # a function call
+                           group("!", alphas) # a negation
+                        )
+                    ),
+                    global = TRUE, locations = TRUE)
+  line_number <- length(source_file$file_lines)
+  lints <- list()
+  while (line_number > 0L && !is.na(res[[line_number]][["start"]])) {
+    lints[[length(lints) + 1L]] <- Lint(
+      filename = source_file$filename,
+      line_number = line_number,
+      column_number = res[[line_number]][["start"]],
+      type = "style",
+      message = "Commented code should be removed.",
+      line = source_file$file_lines[[line_number]],
+      linter = "commented_code_linter"
+    )
+    line_number <- line_number - 1L
+  }
+  invisible(lints)
+}

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -1,0 +1,25 @@
+context("commented_code_linter")
+test_that("returns the correct linting", {
+  expect_lint("blah",
+    NULL,
+    commented_code_linter)
+
+  expect_lint("# blah <- 1",
+    rex("Commented code should be removed"),
+    commented_code_linter)
+
+  expect_lint("bleurgh <- fun_call(1) # other_call()",
+    c(message = rex("Commented code should be removed"),
+      column_number = 24),
+    commented_code_linter)
+
+  expect_lint(" #blah <- 1",
+    c(message = rex("Commented code should be removed"),
+      column_number = 2),
+    commented_code_linter)
+
+  expect_lint("#' blah <- 1",
+    NULL,
+    commented_code_linter)
+
+})


### PR DESCRIPTION
This linter looks for code-like comments, allowing roxygen blocks which may contain examples.