### PR TITLE
Fixes bug where only the results of the first check condition being used

### DIFF
--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -17,16 +17,16 @@ expect_lint <- function(content, checks, ..., file = NULL) {
     content <- readChar(file, file.info(file)$size)
   }
 
-    results <- expectation_lint(content, checks, ...)
+  results <- expectation_lint(content, checks, ...)
 
   reporter <- testthat::get_reporter()
 
-  # flatten list if a list of lists
+  # flatten list if a list of lists of expectations
   if (is.list(results) &&
-    is.list(results[[1]]) &&
-    !testthat::is.expectation(results[[1]])) {
+      is.list(results[[1]]) &&
+      !testthat::is.expectation(results[[1]])) {
 
-    results <- unlist(recursive = FALSE, results)
+    results <- unlist(results, recursive = FALSE)
   }
 
   if (testthat::is.expectation(results)) {
@@ -50,12 +50,18 @@ expectation_lint <- function(content, checks, ...) {
   linter_names <- substitute(alist(...))[-1]
 
   if (is.null(checks)) {
-    return(testthat::expectation(length(lints) %==% 0L,
-        paste0(paste(collapse=", ", linter_names),
+    return(
+      testthat::expectation(
+        length(lints) %==% 0L,
+        paste0(
+          paste(collapse=", ", linter_names),
           " returned ", print(lints),
           " lints when it was expected to return none!"),
-        paste0(paste(collapse=", ", linter_names),
-          " returned 0 lints as expected.")))
+          paste0(paste(collapse=", ", linter_names),
+          " returned 0 lints as expected."
+        )
+      )
+    )
   }
 
   if (!is.list(checks)) {
@@ -64,14 +70,21 @@ expectation_lint <- function(content, checks, ...) {
   checks[] <- lapply(checks, fix_names, "message")
 
   if (length(lints) != length(checks)) {
-    return(testthat::expectation(FALSE,
-        paste0(paste(collapse=", ", linter_names),
+    return(
+      testthat::expectation(
+        FALSE,
+        paste0(
+          paste(collapse=", ", linter_names),
           " did not return ", length(checks),
-          " lints as expected from content:", content, lints)))
+          " lints as expected.\n",
+          paste(lints, collapse="\n")
+        )
+      )
+    )
   }
 
   itr <- 0L #nolint
-  res <- mapply(function(lint, check) {
+  mapply(function(lint, check) {
     itr <- itr + 1L
     lapply(names(check), function(field) {
       value <- lint[[field]]
@@ -111,7 +124,6 @@ expectation_lint <- function(content, checks, ...) {
   },
   lints,
   checks)
-  res[[1]]
 }
 
 #' Test that the package is lint free


### PR DESCRIPTION
Existing implementation only evaluates the first check condition, the following code should fail:

```
# should fail
lintr:::expect_lint(
    "a=1",
     list(c(line_number=1, column_number=3)),
     assignment_linter
)
```