### PR TITLE
fix CI environment detection

### DIFF
--- a/R/comments.R
+++ b/R/comments.R
@@ -1,5 +1,5 @@
 in_ci <- function() {
-  isTRUE(logical_env(Sys.getenv("CI")))
+  isTRUE(logical_env("CI"))
 }
 
 ci_type <- function() {

--- a/tests/testthat/test-comments.R
+++ b/tests/testthat/test-comments.R
@@ -1,0 +1,11 @@
+context("comments")
+test_that("it detects CI environments", {
+  org_value <- Sys.getenv("CI")
+  Sys.setenv(CI="true")
+  expect_true(in_ci())
+  Sys.setenv(CI="false")
+  expect_false(in_ci())
+  Sys.setenv(CI="")
+  expect_false(in_ci())
+  Sys.setenv(CI=org_value)
+})


### PR DESCRIPTION
Currently, the `CI` environment variable is double dereferenced, first in `in_ci` and the result again in `logical_env`. For me, this makes `in_ci` always return `FALSE` and disables commenting. 

This fixes the problem and adds a short unittest.