### PR TITLE
Exclude checking `!` from spaces_left_parentheses_linter

### DIFF
--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -23,8 +23,9 @@ spaces_left_parentheses_linter <- function(source_file) {
         before_operator <- substr(line, parsed$col1 - 1L, parsed$col1 - 1L)
 
         non_space_before <- re_matches(before_operator, rex(non_space))
+        non_exclamation <- before_operator != "!"
 
-        if (non_space_before) {
+        if (non_space_before && non_exclamation) {
           Lint(
             filename = source_file$filename,
             line_number = parsed$line1,

--- a/tests/testthat/test-spaces_left_parentheses_linter.R
+++ b/tests/testthat/test-spaces_left_parentheses_linter.R
@@ -25,6 +25,8 @@ test_that("returns the correct linting", {
 
   expect_lint("1 * (1 + 1)", NULL, spaces_left_parentheses_linter)
 
+  expect_lint("!(1 == 1)", NULL, spaces_left_parentheses_linter)
+
   expect_lint("((1 + 1))",
     rex("Place a space before left parenthesis, except in a function call."),
     spaces_left_parentheses_linter)


### PR DESCRIPTION
HI @jimhester, 

I tried to exclude checking `!` before a left parenthesis from `spaces_left_parentheses` in order to pass like `!(a == b)`. Could you review it?

Thanks,
Yu