### PR TITLE
#77 Add ":" and "[" into the rule for a space before a left parentheses

### DIFF
--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -23,9 +23,9 @@ spaces_left_parentheses_linter <- function(source_file) {
         before_operator <- substr(line, parsed$col1 - 1L, parsed$col1 - 1L)
 
         non_space_before <- re_matches(before_operator, rex(non_space))
-        non_exclamation <- before_operator != "!"
+        not_exception <- !(before_operator %in% c("!", ":", "["))
 
-        if (non_space_before && non_exclamation) {
+        if (non_space_before && not_exception) {
           Lint(
             filename = source_file$filename,
             line_number = parsed$line1,

--- a/tests/testthat/test-spaces_left_parentheses_linter.R
+++ b/tests/testthat/test-spaces_left_parentheses_linter.R
@@ -27,6 +27,14 @@ test_that("returns the correct linting", {
 
   expect_lint("!(1 == 1)", NULL, spaces_left_parentheses_linter)
 
+  expect_lint("(2 - 1):(3 - 1)", NULL, spaces_left_parentheses_linter)
+
+  expect_lint("c(1, 2, 3)[(2 - 1)]", NULL, spaces_left_parentheses_linter)
+
+  expect_lint("list(1, 2, 3)[[(2 - 1)]]", NULL, spaces_left_parentheses_linter)
+
+  expect_lint("range(10)[(2 - 1):(10 - 1)]", NULL, spaces_left_parentheses_linter)
+
   expect_lint("((1 + 1))",
     rex("Place a space before left parenthesis, except in a function call."),
     spaces_left_parentheses_linter)


### PR DESCRIPTION
HI @jimhester,

I think it would be more natural to pass the rule for a space before a left parentheses with `:` and `[` as follows.

```
(x - 1):(y - 1)
x[(x - 1):(y - 1)]
```

Thanks,
Yu