### PR TITLE
[#118] fix a bug of `commented_code_linter`: commented code inside roxygen docs

### DIFF
--- a/R/commented_code_linter.R
+++ b/R/commented_code_linter.R
@@ -47,7 +47,9 @@ commented_code_linter <- function(source_file) {
     is_parsable <- parsable(substr(line,
                                    res[line_number, "code.start"],
                                    res[line_number, "code.end"]))
-    if (is_parsable) {
+    is_roxygen_comment <- re_matches(line, rex(start, "#'", any_spaces))
+
+    if (is_parsable && !is_roxygen_comment) {
       Lint(
         filename = source_file$filename,
         line_number = line_number,

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -22,7 +22,7 @@ test_that("returns the correct linting", {
     NULL,
     commented_code_linter)
 
-  expect_lint("#' foo(bar, 2L) # foo(1, 2)",
+  expect_lint("#' foo(bar, 2L) # 1 + 2",
     NULL,
     commented_code_linter)
 

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -22,6 +22,10 @@ test_that("returns the correct linting", {
     NULL,
     commented_code_linter)
 
+  expect_lint("#' foo(bar, 2L) # foo(1, 2)",
+    NULL,
+    commented_code_linter)
+
   expect_lint(c("a <- 1",
                 "# comment without code"),
     NULL,


### PR DESCRIPTION
https://github.com/jimhester/lintr/issues/118