### PR TITLE
Add an example image for Atom

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ In the SublimeLinter User Settings
 
 ### Atom ###
 lintr can be integrated with
-[AtomLinter](https://github.com/AtomLinter) for on the fly linting.
+[Linter](https://github.com/atom-community/linter) for on the fly linting.
+
+![Atom Example](http://i.imgur.com/E1Isi4T.png "Atom Example")
 
 #### Installation ####
 Simply install `linter-lintr` from within Atom or on the command line with:


### PR DESCRIPTION
Adds an example image for Atom in a theme that somewhat matches the existing images.
Corrects the link to linter to the actual repository.

If you would prefer this against the `atom` branch just let me know.