### PR TITLE
infix_spaces_linter should check `=` inside function calls

### DIFF
--- a/R/absolute_paths_linter.R
+++ b/R/absolute_paths_linter.R
@@ -37,7 +37,7 @@ absolute_paths_linter <- function(source_file) {
       rex(quote, x)
     },
     character(1),
-    USE.NAMES=FALSE)
+    USE.NAMES = FALSE)
 
   lapply(ids_with_token(source_file, "STR_CONST"),
     function(id) {
@@ -73,7 +73,7 @@ absolute_paths_rmd_linter <- function(source_file) {
       rex("[", except_any_of("]"), "]", "(", any_spaces, x)
     },
     character(1),
-    USE.NAMES=FALSE)
+    USE.NAMES = FALSE)
 
   newline_locs <-
     c(0L,

--- a/R/cache.R
+++ b/R/cache.R
@@ -29,7 +29,7 @@ load_cache <- function(file, path = NULL) {
   }
 
   file <- basename(file)
-  env <- new.env(parent=emptyenv())
+  env <- new.env(parent = emptyenv())
 
   file_path <- file.path(path, file)
   if (file.exists(file_path)) {
@@ -49,7 +49,7 @@ save_cache <- function(cache, file, path = NULL) {
   if (!file.exists(path)) {
     dir.create(path, recursive = TRUE)
   }
-  save(file = file.path(path, file), envir = cache, list=ls(envir=cache))
+  save(file = file.path(path, file), envir = cache, list = ls(envir = cache))
 }
 
 cache_file <- function(cache, filename, linters, lints) {

--- a/R/comments.R
+++ b/R/comments.R
@@ -63,14 +63,14 @@ github_comment <- function(text, info = NULL, token = settings$comment_token) {
 
   if (!is.null(info$pull) && info$pull != "false") {
     response <- httr::POST("https://api.github.com",
-      path=paste(sep = "/", "repos", info$user, info$repo, "issues", info$pull, "comments"),
-      body = list("body"=jsonlite::unbox(text)),
+      path = paste(sep = "/", "repos", info$user, info$repo, "issues", info$pull, "comments"),
+      body = list("body" = jsonlite::unbox(text)),
       query = list(access_token = token),
       encode = "json")
   } else if (!is.null(info$commit)) {
     response <- httr::POST("https://api.github.com",
-      path=paste(sep = "/", "repos", info$user, info$repo, "commits", info$commit, "comments"),
-      body = list("body"=jsonlite::unbox(text)),
+      path = paste(sep = "/", "repos", info$user, info$repo, "commits", info$commit, "comments"),
+      body = list("body" = jsonlite::unbox(text)),
       query = list(access_token = token),
       encode = "json")
   }

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -43,7 +43,7 @@ expectation_lint <- function(content, checks, ...) {
 
   filename <- tempfile()
   on.exit(unlink(filename))
-  cat(file=filename, content, sep="\n")
+  cat(file = filename, content, sep = "\n")
 
   lints <- lint(filename, ...)
 
@@ -51,10 +51,10 @@ expectation_lint <- function(content, checks, ...) {
 
   if (is.null(checks)) {
     return(testthat::expectation(length(lints) %==% 0L,
-        paste0(paste(collapse=", ", linter_names),
+        paste0(paste(collapse = ", ", linter_names),
           " returned ", print(lints),
           " lints when it was expected to return none!"),
-        paste0(paste(collapse=", ", linter_names),
+        paste0(paste(collapse = ", ", linter_names),
           " returned 0 lints as expected.")))
   }
 
@@ -65,7 +65,7 @@ expectation_lint <- function(content, checks, ...) {
 
   if (length(lints) != length(checks)) {
     return(testthat::expectation(FALSE,
-        paste0(paste(collapse=", ", linter_names),
+        paste0(paste(collapse = ", ", linter_names),
           " did not return ", length(checks),
           " lints as expected from content:", content, lints)))
   }
@@ -115,11 +115,11 @@ expectation_lint <- function(content, checks, ...) {
 }
 
 #' Test that the package is lint free
-#' 
-#' This function is a thin wrapper around lint_package that simply tests there are no 
-#' lints in the package.  It can be used to ensure that your tests fail if the package 
+#'
+#' This function is a thin wrapper around lint_package that simply tests there are no
+#' lints in the package.  It can be used to ensure that your tests fail if the package
 #' contains lints.
-#' 
+#'
 #' @param ... arguments passed to \code{\link{lint_package}}
 #' @export
 expect_lint_free <- function(...) {

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -119,17 +119,17 @@ get_source_expressions <- function(filename) {
 get_source_file <- function(source_file, error = identity) {
 
   e <- tryCatch(
-    source_file$parsed_content <- parse(text=source_file$content, srcfile=source_file, keep.source = TRUE),
+    source_file$parsed_content <- parse(text = source_file$content, srcfile = source_file, keep.source = TRUE),
     error = error)
 
   # This needs to be done twice to avoid
   #   https://bugs.r-project.org/bugzilla/show_bug.cgi?id=16041
   e <- tryCatch(
-    source_file$parsed_content <- parse(text=source_file$content, srcfile=source_file, keep.source = TRUE),
+    source_file$parsed_content <- parse(text = source_file$content, srcfile = source_file, keep.source = TRUE),
     error = error)
 
   if (!inherits(e, "expression")) {
-    assign("e", e,  envir=parent.frame())
+    assign("e", e,  envir = parent.frame())
   }
 
   fix_eq_assign(adjust_columns(getParseData(source_file)))
@@ -281,7 +281,7 @@ fix_eq_assign <- function(pc) {
     }
     pc[next_loc, "parent"] <- id[i]
   }
-  res <- rbind(pc, data.frame(line1, col1, line2, col2, id, parent, token, terminal, text, row.names=id))
+  res <- rbind(pc, data.frame(line1, col1, line2, col2, id, parent, token, terminal, text, row.names = id))
   res[order(res$line1, res$col1, res$line2, res$col2, res$id), ]
 }
 

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -15,6 +15,7 @@ infix_tokens <- c(
   "LEFT_ASSIGN",
   "RIGHT_ASSIGN",
   "EQ_ASSIGN",
+  "EQ_SUB",
   "SPECIAL",
   "'/'",
   "'^'",
@@ -26,7 +27,7 @@ infix_tokens <- c(
 #' @describeIn linters check that all infix operators have spaces around them.
 #' @export
 infix_spaces_linter <- function(source_file) {
-  lapply(ids_with_token(source_file, infix_tokens, fun=`%in%`),
+  lapply(ids_with_token(source_file, infix_tokens, fun = `%in%`),
     function(id) {
       parsed <- with_id(source_file, id)
 
@@ -43,9 +44,9 @@ infix_spaces_linter <- function(source_file) {
       if (non_space_before || (!newline_after && non_space_after)) {
 
         # we only should check spacing if the operator is infix,
-        # which only happens if there are two siblings
+        # which only happens if there is more than one sibling
         is_infix <-
-          length(siblings(source_file$parsed_content, parsed$id, 1)) %==% 2L
+          length(siblings(source_file$parsed_content, parsed$id, 1)) > 1L
 
         start <- end <- parsed$col1
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -75,7 +75,7 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
     lints[[itr <- itr + 1L]] <- source_expressions$error
 
     if (isTRUE(cache)) {
-      cache_lint(lint_cache, list(filename=filename, content=""), "error", source_expressions$error)
+      cache_lint(lint_cache, list(filename = filename, content = ""), "error", source_expressions$error)
     }
   }
 
@@ -213,7 +213,7 @@ Lint <- function(filename, line_number = 1L, column_number = NULL,
       ranges = ranges,
       linter = linter
       ),
-    class="lint")
+    class = "lint")
 }
 
 rstudio_source_markers <- function(lints) {

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -12,20 +12,20 @@ object_usage_linter <-  function(source_file) {
   if (is.null(pkg_name) || inherits(parent_env, "try-error")) {
     parent_env <- globalenv()
   }
-  env <- new.env(parent=parent_env)
+  env <- new.env(parent = parent_env)
 
   globals <- mget(".__global__",
     parent_env,
     ifnotfound = list(NULL))$`.__global__`
 
-  mapply(assign, globals, MoreArgs=list(value = function(...) NULL, envir = env))
+  mapply(assign, globals, MoreArgs = list(value = function(...) NULL, envir = env))
 
   # add file locals to the environment
   try(eval(source_file$parsed_content, envir = env), silent = TRUE)
 
   all_globals <- unique(recursive_ls(env))
 
-  lapply(ids_with_token(source_file, rex(start, "FUNCTION"), fun=re_matches),
+  lapply(ids_with_token(source_file, rex(start, "FUNCTION"), fun = re_matches),
     function(loc) {
       id <- source_file$parsed_content$id[loc]
 
@@ -40,10 +40,10 @@ object_usage_linter <-  function(source_file) {
         suppressMessages(
           fun <- try(eval(
               parse(
-                text=source_file$content,
+                text = source_file$content,
                 keep.source = TRUE
                 ),
-              envir=env), silent = TRUE)
+              envir = env), silent = TRUE)
         )
       )
 

--- a/R/objects_linter.R
+++ b/R/objects_linter.R
@@ -7,7 +7,7 @@ make_object_linter <- function(fun) {
       envir <- try(getNamespace(pkg_name), silent = TRUE)
 
       if (!inherits(envir, "try-error")) {
-        ls(envir=envir)
+        ls(envir = envir)
       }
     }
 

--- a/R/settings.R
+++ b/R/settings.R
@@ -38,7 +38,7 @@ get_setting <- function(setting, config, defaults) {
   if (!is.null(option)) {
     option
   } else if (!is.null(config[[setting]])) {
-    eval(parse(text=config[[setting]]))
+    eval(parse(text = config[[setting]]))
   } else {
     defaults[[setting]]
   }

--- a/R/tree-utils.R
+++ b/R/tree-utils.R
@@ -2,7 +2,7 @@ generate_tree <- function(pc) {
   if (is.null(pc)) {
     return(NULL)
   }
-  edges <- matrix(as.character(c(pc$parent, pc$id)), ncol=2)
+  edges <- matrix(as.character(c(pc$parent, pc$id)), ncol = 2)
   igraph::graph.edgelist(edges, directed = TRUE)
 }
 children <- function(data, id, levels = Inf, simplify = TRUE) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -94,10 +94,10 @@ names2 <- function(x) {
 
 recursive_ls <- function(env) {
   if (parent.env(env) %!=% emptyenv()) {
-    c(ls(envir=env), recursive_ls(parent.env(env)))
+    c(ls(envir = env), recursive_ls(parent.env(env)))
   }
   else {
-    ls(envir=env)
+    ls(envir = env)
   }
 }
 

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -32,7 +32,7 @@ test_that("returns the correct linting", {
     NULL,
     commented_code_linter)
 
-  test_ops <- append(ops[ops != "%[^%]*%"], values= c("%>%", "%anything%"))
+  test_ops <- append(ops[ops != "%[^%]*%"], values = c("%>%", "%anything%"))
   for (op in test_ops) {
     expect_lint(paste("i", op, "1", collapse = ""), NULL, commented_code_linter)
 

--- a/tests/testthat/test-comments.R
+++ b/tests/testthat/test-comments.R
@@ -1,12 +1,12 @@
 context("comments")
 test_that("it detects CI environments", {
   org_value <- Sys.getenv("CI")
-  on.exit(Sys.setenv(CI=org_value), add = TRUE)
+  on.exit(Sys.setenv(CI = org_value), add = TRUE)
 
-  Sys.setenv(CI="true")
+  Sys.setenv(CI = "true")
   expect_true(in_ci())
-  Sys.setenv(CI="false")
+  Sys.setenv(CI = "false")
   expect_false(in_ci())
-  Sys.setenv(CI="")
+  Sys.setenv(CI = "")
   expect_false(in_ci())
 })

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -136,14 +136,14 @@ test_that("it handles full file exclusions", {
 
 test_that("it handles redundant lines", {
 
-  expect_equal(normalize_exclusions(list(a=c(1, 1, 1:10))), list(a = 1:10))
+  expect_equal(normalize_exclusions(list(a = c(1, 1, 1:10))), list(a = 1:10))
 
-  expect_equal(normalize_exclusions(list(a=c(1, 1, 1:10), b = 1:10)), list(a = 1:10, b = 1:10))
+  expect_equal(normalize_exclusions(list(a = c(1, 1, 1:10), b = 1:10)), list(a = 1:10, b = 1:10))
 })
 
 test_that("it handles redundant files", {
 
-  expect_equal(normalize_exclusions(list(a=c(1:10), a=c(10:20))), list(a = 1:20))
+  expect_equal(normalize_exclusions(list(a = c(1:10), a = c(10:20))), list(a = 1:20))
 })
 
 context("exclude")

--- a/tests/testthat/test-infix_spaces_linter.R
+++ b/tests/testthat/test-infix_spaces_linter.R
@@ -60,4 +60,8 @@ test_that("returns the correct linting", {
   expect_lint("a[-1 + 1]", NULL, infix_spaces_linter)
 
   expect_lint("a[1 + -1]", NULL, infix_spaces_linter)
+
+  expect_lint("fun(a=1)",
+    rex("Put spaces around all infix operators."),
+    infix_spaces_linter)
 })

--- a/tests/testthat/test-knitr_formats.R
+++ b/tests/testthat/test-knitr_formats.R
@@ -1,6 +1,6 @@
 context("knitr_formats")
 test_that("it handles markdown", {
-  expect_lint(file="knitr_formats/test.Rmd",
+  expect_lint(file = "knitr_formats/test.Rmd",
     checks = list(
       rex("Use <-, not =, for assignment."),
       rex("local variable"),
@@ -11,7 +11,7 @@ test_that("it handles markdown", {
   )
 })
 test_that("it handles Sweave", {
-  expect_lint(file="knitr_formats/test.Rnw",
+  expect_lint(file = "knitr_formats/test.Rnw",
     checks = list(
       rex("Use <-, not =, for assignment."),
       rex("local variable"),
@@ -22,7 +22,7 @@ test_that("it handles Sweave", {
   )
 })
 test_that("it handles reStructuredText", {
-  expect_lint(file="knitr_formats/test.Rrst",
+  expect_lint(file = "knitr_formats/test.Rrst",
     checks = list(
       rex("Use <-, not =, for assignment."),
       rex("local variable"),
@@ -33,7 +33,7 @@ test_that("it handles reStructuredText", {
   )
 })
 test_that("it handles HTML", {
-  expect_lint(file="knitr_formats/test.Rhtml",
+  expect_lint(file = "knitr_formats/test.Rhtml",
     checks = list(
       rex("Use <-, not =, for assignment."),
       rex("local variable"),
@@ -44,7 +44,7 @@ test_that("it handles HTML", {
   )
 })
 test_that("it handles tex", {
-  expect_lint(file="knitr_formats/test.Rtex",
+  expect_lint(file = "knitr_formats/test.Rtex",
     checks = list(
       rex("Use <-, not =, for assignment."),
       rex("local variable"),
@@ -55,7 +55,7 @@ test_that("it handles tex", {
   )
 })
 test_that("it handles asciidoc", {
-  expect_lint(file="knitr_formats/test.Rtxt",
+  expect_lint(file = "knitr_formats/test.Rtxt",
     checks = list(
       rex("Use <-, not =, for assignment."),
       rex("local variable"),


### PR DESCRIPTION
If I'm not mistaken, according to the style guide and your current code implementation, `=` is meant to be linted. However it seems that `=` inside function calls is a differently named token versus plain `=` assignment. I have added `EQ_SUB` to the list to capture that.

In addition, `=` inside function calls treats the entire function call as its parent. Therefore I changed the siblings check to be "greater than one" rather than "equal to two". If I understand your intention correctly, this check is meant to prevent false positive like `-1, <2` etc. So far I haven't been able to come up or find any false positives my change would introduce.

Let me know if I missed anything or incorrectly interpreted the style guide.