### PR TITLE
fix cache logic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # lintr 1.0.0.9000 #
 
+* Fixed lint_package bug where cache was not caching (#146, @schloerke)
 * Commas linter handles missing arguments calls properly (#145)
 
 # lintr 1.0.0 #

--- a/R/lint.R
+++ b/R/lint.R
@@ -47,7 +47,7 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
     cacheDir <- character(0)
   }
 
-  if (length(cache)) {
+  if (length(cacheDir)) {
     lint_cache <- load_cache(filename, cacheDir)
     lints <- retrieve_file(lint_cache, filename, linters)
     if (!is.null(lints)) {

--- a/R/lint.R
+++ b/R/lint.R
@@ -43,7 +43,9 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
 
   if (isTRUE(cache)) {
     cacheDir <- settings$cache_directory
-  } else if (is.logical(cache)) {
+  } else if (is.character(cache)) {
+    cacheDir <- cache
+  } else {
     cacheDir <- character(0)
   }
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -42,15 +42,15 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
   itr <- 0
 
   if (isTRUE(cache)) {
-    cacheDir <- settings$cache_directory
+    cache_dir <- settings$cache_directory
   } else if (is.character(cache)) {
-    cacheDir <- cache
+    cache_dir <- cache
   } else {
-    cacheDir <- character(0)
+    cache_dir <- character(0)
   }
 
-  if (length(cacheDir)) {
-    lint_cache <- load_cache(filename, cacheDir)
+  if (length(cache_dir)) {
+    lint_cache <- load_cache(filename, cache_dir)
     lints <- retrieve_file(lint_cache, filename, linters)
     if (!is.null(lints)) {
       return(exclude(lints, ...))

--- a/R/lint.R
+++ b/R/lint.R
@@ -122,6 +122,7 @@ lint_package <- function(path = ".", relative_path = TRUE, ...) {
   on.exit(clear_settings, add = TRUE)
 
   names(settings$exclusions) <- normalizePath(file.path(path, names(settings$exclusions)))
+  exclusions = force(settings$exclusions)
 
   files <- dir(
     path = file.path(path,
@@ -141,7 +142,7 @@ lint_package <- function(path = ".", relative_path = TRUE, ...) {
         if (interactive()) {
           message(".", appendLF = FALSE)
         }
-        lint(file, ..., parse_settings = FALSE)
+        lint(file, ..., parse_settings = FALSE, exclusions = exclusions)
       }))
 
   if (interactive()) {

--- a/R/lint.R
+++ b/R/lint.R
@@ -42,17 +42,20 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
   itr <- 0
 
   if (isTRUE(cache)) {
-    cache <- settings$cache_directory
+    cacheDir <- settings$cache_directory
   } else if (is.logical(cache)) {
-    cache <- character(0)
+    cacheDir <- character(0)
   }
 
   if (length(cache)) {
-    lint_cache <- load_cache(filename, cache)
+    lint_cache <- load_cache(filename, cacheDir)
     lints <- retrieve_file(lint_cache, filename, linters)
     if (!is.null(lints)) {
       return(exclude(lints, ...))
     }
+    cache = TRUE
+  } else {
+    cache = FALSE
   }
 
   for (expr in source_expressions$expressions) {


### PR DESCRIPTION
Hi Jim,

when turning on the cache flag, I wasn't getting any speed improvements.  With this pull request, files are being saved and compute much faster.

(on the GGally package...)
```{r}
load_all("../../../lintr/lintr/"); 
# cache empty
system.time({lint_package(cache = TRUE)})
# Loading lintr
# .............................................
#    user  system elapsed 
# 116.968   1.501 121.804 

# cache filled
system.time({lint_package(cache = TRUE)})
# .............................................
#    user  system elapsed 
#  11.891   0.275  12.743 
```

Best,
Barret