### PR TITLE
Replace igraph calls with our own R code, get rid of igraph

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
     stringdist,
     testthat,
     digest,
-    igraph,
     rstudioapi (>= 0.2),
     httr,
     jsonlite,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 # lintr 1.0.0.9000 #
+* lintr does not need the igraph package any more (#152, @gaborcsardi)
+
 * trailing_semicolon_linter (#147, @gaborcsardi)
 
 * Commas linter handles missing arguments calls properly (#145)

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -89,7 +89,7 @@ get_source_expressions <- function(filename) {
     content <- get_content(expr_lines, parsed_content[loc, ])
 
     id <- as.character(parsed_content$id[loc])
-    edges <- igraph::E(tree)[from(igraph::subcomponent(tree, id, mode = "out"))]
+    edges <- component_edges(tree, id)
     pc <- parsed_content[c(loc, edges), ]
     list(
       filename = filename,

--- a/R/tree-utils.R
+++ b/R/tree-utils.R
@@ -3,8 +3,32 @@ generate_tree <- function(pc) {
     return(NULL)
   }
   edges <- matrix(as.character(c(pc$parent, pc$id)), ncol = 2)
-  igraph::graph.edgelist(edges, directed = TRUE)
+  list(edges = edges, adjlist = adjlist_from_edgelist(edges))
 }
+
+## Create an adjacency list from an edge list
+
+adjlist_from_edgelist <- function(edges) {
+  tapply(edges[, 2], edges[, 1], c, simplify = FALSE)
+}
+
+## Take the subcomponent of id (mode out), and then all edges
+## that start at these vertices
+
+component_edges <- function(graph, id) {
+  sc <- newv <- unique(id)
+  size <- length(sc)
+  repeat {
+    neis <- unlist(graph$adjlist[newv])
+    newv <- setdiff(neis, sc)
+    sc <- c(sc, newv)
+    if (length(sc) == size) break;
+    size <- length(sc)
+  }
+
+  which(graph$edges[, 1] %in% sc)
+}
+
 children <- function(data, id, levels = Inf, simplify = TRUE) {
 
   child_ids <- function(ids) {


### PR DESCRIPTION
It is also faster, at least the complicated QC.R case. I also profiled it for this file, it is as fast as it gets, `self.time: 0.00`, `self.pct: 0.00`. :)