### PR TITLE
seq_linter fixes: 1L:length(...) and length(...):1

### DIFF
--- a/tests/testthat/test-seq_linter.R
+++ b/tests/testthat/test-seq_linter.R
@@ -27,3 +27,15 @@ test_that("finds 1:length(...) expressions", {
     rex("NCOL(...) expressions, use seq_len"),
     seq_linter)
 })
+
+test_that("1L is also bad", {
+  expect_lint("function(x) { 1L:length(x) }",
+    rex("1L:length(...) expressions, use seq_len"),
+    seq_linter)
+})
+
+test_that("reverse seq is ok", {
+  expect_lint("function(x) { length(x):1 }",
+    rex("length(...):1 expressions, use seq_len"),
+    seq_linter)
+})


### PR DESCRIPTION
Some fixes for the new seq_linter:

* Find `1L:length(...)`, etc. expressions as well.
* Proper printout for the `length(...):1` expressions. Somewhat surprisingly, these are found, too, there is no order in the XPath search.
