### PR TITLE
Fix for syntastic error in VIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ in `syntastic/syntax_checkers/r`.  If you are using
 You will also need to add the following lines to your `.vimrc`.
 ```vim
 let g:syntastic_enable_r_lintr_checker = 1
-let g:syntastic_r_checkers = 1
+let g:syntastic_r_checkers = ['lintr']
 ```
 #### Configuration ####
 You can also configure what linters are used. e.g. using a different line length cutoff.


### PR DESCRIPTION
Syntastic expects a list of strings here. The current proposed settings leads to the error:

    syntastic: error: variable g:syntastic_r_checkers has to be a list of strings