### PR TITLE
Don't lint identifiers within library imports

### DIFF
--- a/tests/testthat/checkstyle.xml
+++ b/tests/testthat/checkstyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="lintr-1.0.0.9001">
   <file name="test_file">
     <error line="1" column="2" severity="error" message="foo"/>

--- a/tests/testthat/test-object_camel_case_linter.R
+++ b/tests/testthat/test-object_camel_case_linter.R
@@ -20,6 +20,14 @@ test_that("returns the correct linting", {
     NULL,
     camel_case_linter)
 
+  expect_lint("library(camelCase)",
+    NULL,
+    camel_case_linter)
+
+  expect_lint("require(camelCase)",
+    NULL,
+    camel_case_linter)
+
   expect_lint("pack:::camelCase",
     NULL,
     camel_case_linter)

--- a/tests/testthat/test-object_snake_case_linter.R
+++ b/tests/testthat/test-object_snake_case_linter.R
@@ -16,6 +16,13 @@ test_that("returns the correct linting", {
     rex("Variable and function names should not use underscores."),
     snake_case_linter)
 
+  expect_lint("library(snake_case)",
+    NULL,
+    snake_case_linter)
+
+  expect_lint("require(snake_case)",
+    NULL,
+    snake_case_linter)
 
   expect_lint("pack::snake_case",
     NULL,


### PR DESCRIPTION
Fixes #201 for both camel case and snake case linters.