### PR TITLE
Fix test error

### DIFF
--- a/tests/testthat/checkstyle.xml
+++ b/tests/testthat/checkstyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle version="lintr-1.0.0.9001">
   <file name="test_file">
     <error line="1" column="2" severity="error" message="foo"/>


### PR DESCRIPTION
Update the checkstyle.xml file because xml2 now explicitly sets the encoding of generated xml files. See the comment in PR #202.