### PR TITLE
Fix case for line_length_linter message

### DIFF
--- a/R/line_length_linter.R
+++ b/R/line_length_linter.R
@@ -15,7 +15,7 @@ line_length_linter <- function(length) {
           line_number = line_number,
           column_number = col_start,
           type = "style",
-          message = sprintf("lines should not be more than %d characters.", length),
+          message = sprintf("Lines should not be more than %d characters.", length),
           line = line,
           ranges = list(c(col_start, col_end)),
           linter = "line_length_linter"

--- a/tests/testthat/test-line_length_linter.R
+++ b/tests/testthat/test-line_length_linter.R
@@ -10,7 +10,7 @@ test_that("returns the correct linting", {
     line_length_linter(80))
 
   expect_lint("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-    "lines should not be more than 80 characters",
+    "Lines should not be more than 80 characters",
     line_length_linter(80))
 
   expect_lint(
@@ -18,8 +18,8 @@ test_that("returns the correct linting", {
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 
     list(
-      rex("lines should not be more than 80 characters"),
-      rex("lines should not be more than 80 characters")),
+      rex("Lines should not be more than 80 characters"),
+      rex("Lines should not be more than 80 characters")),
 
     line_length_linter(80))
 
@@ -28,6 +28,6 @@ test_that("returns the correct linting", {
     line_length_linter(20))
 
   expect_lint("aaaaaaaaaaaaaaaaaaaab",
-    rex("lines should not be more than 20 characters"),
+    rex("Lines should not be more than 20 characters"),
     line_length_linter(20))
 })


### PR DESCRIPTION
While other linters' messages start with upper case characters (as they are full sentences), `line_length_linter` prints a message starting with a lower case character.

This patch adjusts `line_length_linter` accordingly.