### PR TITLE
Tab correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # lintr 1.0.0.9001 #
+* Added proper handling of tab characters (fixes #44, @fangly)
 * Fix line number sometimes wrongly reported by no_tab_linter() (#134, @fangly)
 * Fix line and column number sometimes wrongly reported by spaces_inside_linter()
   (#203, @fangly)

--- a/R/extract.R
+++ b/R/extract.R
@@ -34,7 +34,6 @@ extract_r_source <- function(filename, lines) {
       }
     },
     starts, ends)
-  output
   replace_prefix(output, pattern$chunk.code)
 }
 

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -170,7 +170,7 @@ find_column_fun <- function(content) {
 
 # Adjust the columns that getParseData reports from bytes to characters.
 fix_column_numbers <- function(content) {
-  if (is.null(pc)) {
+  if (is.null(content)) {
     return(NULL)
   }
 
@@ -226,19 +226,12 @@ fix_tab_indentations <- function(source_file) {
     return(NULL)
   }
 
-  tab_cols <- re_matches(source_file[["lines"]], "\t", global = TRUE, locations = TRUE)
-  names(tab_cols) <- seq_along(tab_cols)
+
   tab_cols <- lapply(
-    tab_cols,
-    function(cols) {
-      start_cols <- cols[["start"]]
-      if (!is.na(start_cols[[1L]])) {
-        start_cols
-      } else {
-        NA
-      }
-    }
+    gregexpr("\t", source_file[["lines"]], fixed = TRUE),
+    function(x) {if (is.na(x) || x[[1L]] < 0L) {NA} else {x}}
   )
+  names(tab_cols) <- seq_along(tab_cols)
   tab_cols <- tab_cols[!is.na(tab_cols)]
 
   for (line in names(tab_cols)) {

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -208,9 +208,9 @@ adjust_columns <- function(content) {
 
 # Restore column numbers without tab indentation
 #
-# parse() and thus getParseData() count 1 tab as a variable number of spaces (see src/main/gram.c).
-# The number of spaces is just so that the code is brought to the next 8-character indentation level
-# e.g.:
+# parse() and thus getParseData() count 1 tab as a variable number of spaces:
+# https://github.com/wch/r-source/blame/e7401b68ab0e032fce3e376aaca9a5431619b2b4/src/main/gram.y#L512
+# The number of spaces is so that the code is brought to the next 8-character indentation level e.g:
 #   "1\t;"          -> "1       ;"
 #   "12\t;"         -> "12      ;"
 #   "123\t;"        -> "123     ;"

--- a/R/lint.R
+++ b/R/lint.R
@@ -212,11 +212,11 @@ pkg_name <- function(path = find_package()) {
 #' Create a \code{Lint} object
 #' @param filename path to the source file that was linted.
 #' @param line_number line number where the lint occurred.
-#' @param column_number column the lint occurred.
+#' @param column_number column number where the lint occurred.
 #' @param type type of lint.
 #' @param message message used to describe the lint error
 #' @param line code source where the lint occured
-#' @param ranges ranges on the line that should be emphasized.
+#' @param ranges a list of ranges on the line that should be emphasized.
 #' @param linter name of linter that created the Lint object.
 #' @export
 Lint <- function(filename, line_number = 1L, column_number = 1L,

--- a/R/no_tab_linter.R
+++ b/R/no_tab_linter.R
@@ -26,9 +26,6 @@ no_tab_linter <- function(source_file) {
             type = "style",
             message = "Use spaces to indent, not tabs.",
             line = source_file$lines[[as.character(line_number)]],
-
-            # R outputs tabs with 8 spaces
-            # TODO: this is incorrect for embedded tabs, I am not going to fix it.
             ranges = list(c(start, end)),
             linter = "no_tab_linter"
           )

--- a/man/Lint.Rd
+++ b/man/Lint.Rd
@@ -13,7 +13,7 @@ Lint(filename, line_number = 1L, column_number = 1L, type = c("style",
 
 \item{line_number}{line number where the lint occurred.}
 
-\item{column_number}{column the lint occurred.}
+\item{column_number}{column number where the lint occurred.}
 
 \item{type}{type of lint.}
 
@@ -21,7 +21,7 @@ Lint(filename, line_number = 1L, column_number = 1L, type = c("style",
 
 \item{line}{code source where the lint occured}
 
-\item{ranges}{ranges on the line that should be emphasized.}
+\item{ranges}{a list of ranges on the line that should be emphasized.}
 
 \item{linter}{name of linter that created the Lint object.}
 }

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -27,9 +27,9 @@ test_that("tab positions have been corrected", {
     expect_equivalent(pc[[1]][pc[[1L]][["text"]] == "TRUE", c("col1", "col2")], c(3L, 6L))
   )
 
-  with_content_to_parse("n\t<=\tTRUE", {
-    expect_equivalent(pc[[1L]][pc[[1L]][["text"]] == "n", c("col1", "col2")], c(1L, 1L))
-    expect_equivalent(pc[[1L]][pc[[1L]][["text"]] == "<=", c("col1", "col2")], c(3L, 4L))
+  with_content_to_parse("x\t<-\tTRUE", {
+    expect_equivalent(pc[[1L]][pc[[1L]][["text"]] == "x", c("col1", "col2")], c(1L, 1L))
+    expect_equivalent(pc[[1L]][pc[[1L]][["text"]] == "<-", c("col1", "col2")], c(3L, 4L))
     expect_equivalent(pc[[1L]][pc[[1L]][["text"]] == "TRUE", c("col1", "col2")], c(6L, 9L))
   })
 
@@ -49,6 +49,14 @@ test_that("tab positions have been corrected", {
     expect_equivalent(
       pc[[3L]][pc[[3L]][["text"]] == "3", c("line1", "col1", "col2")],
       c(4L, 10L, 10L)
+    )
+  })
+
+  with_content_to_parse("function(){\nTRUE\n\t}", {
+    expect_equivalent(
+      pc[[1L]][1L, c("line1", "col1", "line2", "col2")],
+      c(1L, 1L, 3L, 2L),
+      info = "expression that spans several lines"
     )
   })
 })

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -1,0 +1,42 @@
+context("get_source_expression")
+
+test_that("tab positions have been corrected", {
+  f <- tempfile()
+
+  writeLines("1\n\t", f)
+  expect_error(lintr:::get_source_expressions(f), NA, label="empty parsed_content line")
+
+  writeLines("TRUE", f)
+  pc <- lintr:::get_source_expressions(f)[["expressions"]][[1L]][["parsed_content"]]
+  expect_equivalent(pc[pc[["text"]] == "TRUE", c("col1", "col2")], c(1L, 4L))
+
+  writeLines("\tTRUE", f)
+  pc <- lintr:::get_source_expressions(f)[["expressions"]][[1L]][["parsed_content"]]
+  expect_equivalent(pc[pc[["text"]] == "TRUE", c("col1", "col2")], c(2L, 5L))
+
+  writeLines("\t\tTRUE", f)
+  pc <- lintr:::get_source_expressions(f)[["expressions"]][[1L]][["parsed_content"]]
+  expect_equivalent(pc[pc[["text"]] == "TRUE", c("col1", "col2")], c(3L, 6L))
+
+  writeLines("n\t<=\tTRUE", f)
+  pc <- lintr:::get_source_expressions(f)[["expressions"]][[1L]][["parsed_content"]]
+  expect_equivalent(pc[pc[["text"]] == "n", c("col1", "col2")], c(1L, 1L))
+  expect_equivalent(pc[pc[["text"]] == "<=", c("col1", "col2")], c(3L, 4L))
+  expect_equivalent(pc[pc[["text"]] == "TRUE", c("col1", "col2")], c(6L, 9L))
+
+  writeLines("\tfunction\t(x)\t{\tprint(pc[\t,1])\t;\t}", f)
+  pc <- lintr:::get_source_expressions(f)[["expressions"]][[1L]][["parsed_content"]]
+  expect_equivalent(pc[pc[["text"]] == "function", c("col1", "col2")], c(2L, 9L))
+  expect_equivalent(pc[pc[["text"]] == "x", c("col1", "col2")], c(12L, 12L))
+  expect_equivalent(pc[pc[["text"]] == "print", c("col1", "col2")], c(17L, 21L))
+  expect_equivalent(pc[pc[["text"]] == ";", c("col1", "col2")], c(32L, 32L))
+  expect_equivalent(pc[pc[["text"]] == "}", c("col1", "col2")], c(34L, 34L))
+
+  writeLines("# test tab\n\ns <- 'I have \\t a dog'\nrep(\ts, \t3)", f)
+  y <- lintr:::get_source_expressions(f)[["expressions"]]
+  pc <- y[[2]][["parsed_content"]]
+  expect_equivalent(pc[pc[["token"]] == "STR_CONST", c("line1", "col1", "col2")], c(3L, 6L, 22L))
+  pc <- y[[3]][["parsed_content"]]
+  expect_equivalent(pc[pc[["token"]] == "NUM_CONST", c("line1", "col1", "col2")], c(4L, 10L, 10L))
+
+})

--- a/tests/testthat/test-no_tab_linter.R
+++ b/tests/testthat/test-no_tab_linter.R
@@ -10,9 +10,15 @@ test_that("returns the correct linting", {
 
   expect_lint("#\tblah", NULL, no_tab_linter)
 
-  expect_lint("\tblah", c(message = msg, line_number = 1L), no_tab_linter)
+  expect_lint(
+    "\tblah",
+    list(c(message = msg, line_number = 1L, column_number = 1L)),
+    no_tab_linter
+  )
 
-  expect_lint("\n\t\tblah", c(message = msg, line_number = 2L), no_tab_linter)
-
-  # Note: no tests of column number since they are currently incorrect (tabs converted to 8 spaces)
+  expect_lint(
+    "\n\t\t\tblah",
+    list(c(message = msg, line_number = 2L, column_number = 1L)),
+    no_tab_linter
+  )
 })


### PR DESCRIPTION
Hi Jim,

Please have a look at this PR which adds proper handling for tab character in source code. As you know, the R parser expands tab characters into a variable number of space characters (for 8-character wide indentation). This PR fixes the column numbers in the parsed_content table.

This is a change to a central piece of code, hence the PR. I have added various tests for this and the complete test suite passes successfully.

Cheers,

Florent