### PR TITLE
Recognize .R scripts that contain Roxygen inline expressions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,7 @@
 * Commas linter handles missing arguments calls properly (#145)
 * Add `function_left_parentheses_linter` to check that there is no space between
   a function name and its left parentheses (#204, @jrnold).
-* Recognize .R scripts that contain Roxygen inline expressions as simply .R scripts (@wildoane)
+* Recognize .R scripts that contain Roxygen inline expressions as simply .R scripts (#246, @wildoane)
 
 # lintr 1.0.0 #
 * bugfix to work with testthat 1.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 * Commas linter handles missing arguments calls properly (#145)
 * Add `function_left_parentheses_linter` to check that there is no space between
   a function name and its left parentheses (#204, @jrnold).
+* Recognize .R scripts that contain Roxygen inline expressions as simply .R scripts (@wildoane)
 
 # lintr 1.0.0 #
 * bugfix to work with testthat 1.0.0

--- a/R/extract.R
+++ b/R/extract.R
@@ -41,7 +41,12 @@ detect_pattern <- get("detect_pattern", asNamespace("knitr"))
 file_ext <- get("file_ext", asNamespace("knitr"))
 
 get_knitr_pattern <- function(filename, lines) {
-  pattern <- detect_pattern(lines, tolower(file_ext(filename)))
+  if (tolower(file_ext(filename)) == "r") {
+    pattern <- NULL
+  } else {
+    pattern <- detect_pattern(lines, tolower(file_ext(filename)))
+  }
+  
   if (!is.null(pattern)) {
     knitr::all_patterns[[pattern]]
   } else {


### PR DESCRIPTION
knitr::detect_pattern() incorrectly identifies .R scripts that contain Roxygen inline expressions as Markdown documents, causing a fatal error.

The following should lint 2 results (long var name and use of =), but errors due to either \`r\` expression.

```
#' ---
#' date: "`r Sys.Date()`"
#' ---

an_extremely_long_variable_name = Sys.Date()

#' Today is `r Sys.Date()` according to R.

```