### PR TITLE
Adds RStudio addins

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Collate:
     'T_and_F_symbol_linter.R'
     'utils.R'
     'aaa.R'
+    'addins.R'
     'assignment_linter.R'
     'cache.R'
     'closed_curly_linter.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # lintr 1.0.1.9001 #
+* RStudio addins to lint current source and project (fixes #264, @JhossePaul)
 * Export expect_lint() (#178, #210)
 * Added proper handling of tab characters (fixes #44, @fangly)
 * Fix line number sometimes wrongly reported by no_tab_linter() (#134, @fangly)

--- a/R/addins.R
+++ b/R/addins.R
@@ -3,7 +3,18 @@ addin_lint <- function() {
   if (filename$path == "") {
     return("Current source has no path. Please save before continue")
   }
-  lintr::lint(filename$path)
+
+  config_file <- lintr:::find_config(filename$path)
+  config <- read.dcf(config_file, all = T)
+  config_linters <- gsub("\n", "", config[["linters"]])
+  linters <- if (length(config_linters) == 0) {
+    message("No configuration found. Using default linters.")
+    default_linters
+  } else {
+    eval(parse(text = config_linters))
+  }
+
+  lintr::lint(filename$path, linters = linters)
 }
 
 addin_lint_package <- function() {

--- a/R/addins.R
+++ b/R/addins.R
@@ -1,0 +1,8 @@
+addin_lint <- function () {
+  filename <- rstudioapi::getActiveDocumentContext()
+  lintr::lint(filename$path)
+}
+
+addin_lint_package <- function () {
+  lintr::lint_package()
+}

--- a/R/addins.R
+++ b/R/addins.R
@@ -1,5 +1,5 @@
 addin_lint <- function() {
-  filename <- rstudioapi::getActiveDocumentContext()
+  filename <- rstudioapi::getSourceEditorContext()
   if (filename$path == "") {
     return("Current source has no path. Please save before continue")
   }
@@ -7,7 +7,7 @@ addin_lint <- function() {
 }
 
 addin_lint_package <- function() {
-  project <- rstudioapi::getAciveProject()
+  project <- rstudioapi::getActiveProject()
   project_path <- if (is.null(project)) getwd() else project
 
   if (is.null(project)) message("No project found, passing current directory")

--- a/R/addins.R
+++ b/R/addins.R
@@ -1,8 +1,16 @@
-addin_lint <- function () {
+addin_lint <- function() {
   filename <- rstudioapi::getActiveDocumentContext()
+  if (filename$path == "") {
+    return("Current source has no path. Please save before continue")
+  }
   lintr::lint(filename$path)
 }
 
-addin_lint_package <- function () {
-  lintr::lint_package()
+addin_lint_package <- function() {
+  project <- rstudioapi::getAciveProject()
+  project_path <- if (is.null(project)) getwd() else project
+
+  if (is.null(project)) message("No project found, passing current directory")
+
+  lintr::lint_package(project_path)
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@
 lintr lints are automatically displayed in the RStudio Marker pane, Rstudio versions (> v0.99.206).
 ![RStudio Example](http://i.imgur.com/PIKnpbn.png "Rstudio Example")
 
+This package also includes two addins for linting the current source and package.
+TO bind the addin to a keyboard shortcut navigate to Tools > addins > 
+Browse Addins > Keyboard Shortcuts. It's recommended to use Alt+Shift+L for
+linting the current source code and Ctrl+Shift+Alt+L to code the package.
+These are easy to remember as you are Alt+Shift+L(int) ;)
+
+
 ### Emacs ###
 lintr has [built-in integration](http://www.flycheck.org/en/latest/languages.html#r) with [flycheck](https://github.com/flycheck/flycheck) versions greater than `0.23`.
 ![Emacs Example](http://i.imgur.com/vquPht3.gif "Emacs Example")

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,0 +1,9 @@
+Name: Lint current file
+Description: Runs lintr::lint on the current file
+Binding: addin_lint
+Interative: false
+
+Name: Lint current directory
+Description: Runs lintr::lint_package
+Binding: addin_lint_package
+Interative: false

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -3,7 +3,7 @@ Description: Runs lintr::lint on the current file
 Binding: addin_lint
 Interative: false
 
-Name: Lint current directory
+Name: Lint current package
 Description: Runs lintr::lint_package
 Binding: addin_lint_package
 Interative: false


### PR DESCRIPTION
This commit adds two addins to RStudio to bind shortcuts for easier usage. Now you can, for example, bind
Alt+Shift+L and lint the current source code.