### PR TITLE
fixing bug with missing config file

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -5,8 +5,12 @@ addin_lint <- function() {
   }
 
   config_file <- lintr:::find_config(filename$path)
-  config <- read.dcf(config_file, all = T)
-  config_linters <- gsub("\n", "", config[["linters"]])
+  if (length(config_file) == 0) {
+    config_linters <- NULL
+  } else {
+    config <- read.dcf(config_file, all = T)
+    config_linters <- gsub("\n", "", config[["linters"]])
+  }
   linters <- if (length(config_linters) == 0) {
     message("No configuration found. Using default linters.")
     default_linters


### PR DESCRIPTION
closes #280 (missing config file for using RStudio add-in to `Lint current file`)