### PR TITLE
For fully ignored files, remove from `lint_package` prior to any further processing.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,8 @@
 * Add `function_left_parentheses_linter` to check that there is no space between
   a function name and its left parentheses (#204, @jrnold).
 * Implement `summary.lints()` (#260, #262, @wlandau).
+* Changed `lint_package` to remove fully excluded files as soon as possible to
+  avoid reading and pre-processing of ignored files (@mwaldstein)
 
 # lintr 1.0.1 #
 * bugfix to work with knitr 1.16.7

--- a/R/lint.R
+++ b/R/lint.R
@@ -155,7 +155,6 @@ lint_package <- function(path = ".", relative_path = TRUE, ..., exclusions = NUL
   on.exit(clear_settings, add = TRUE)
 
   exclusions <- normalize_exclusions(c(exclusions, settings$exclusions), FALSE)
-  names(exclusions) <- file.path(path, names(exclusions))
 
   files <- dir(
     path = file.path(path,
@@ -167,6 +166,15 @@ lint_package <- function(path = ".", relative_path = TRUE, ..., exclusions = NUL
     recursive = TRUE,
     full.names = TRUE
   )
+
+  # Remove fully ignored files to avoid reading & parsing
+  to_exclude <- vapply(seq_len(length(files)),
+    function(i) {
+      file <- files[i]
+      file %in% names(exclusions) && exclusions[[file]] == Inf
+     },
+    logical(1))
+  files <- files[!to_exclude]
 
   lints <- flatten_lints(lapply(files,
       function(file) {


### PR DESCRIPTION
For my project, I have a lot of httptest cache files that should not be linted. While I can add them to the exclusions, the current implementation reads in the files before excluding, causing linting to take 30+ min.

This change removes fully excluded files as early as possible to avoid reading them in. 