### PR TITLE
fix: Allow for (( when linting. Fixes #259

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -85,6 +85,7 @@
 * Permit single quotes if they quote literal double quotes (#28, @jackwasey)
 * # nolint comments are respected with caching (#68, @krlmlr)
 * Properly handle all knitr document formats
+* Allow for (( when linting (#259, @nathaneastwood)
 
 # lintr 0.2.0 #
 

--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -24,7 +24,7 @@ spaces_left_parentheses_linter <- function(source_file) {
         before_operator <- substr(line, parsed$col1 - 1L, parsed$col1 - 1L)
 
         non_space_before <- re_matches(before_operator, rex(non_space))
-        not_exception <- !(before_operator %in% c("!", ":", "["))
+        not_exception <- !(before_operator %in% c("!", ":", "[", "("))
 
         if (non_space_before && not_exception) {
           Lint(


### PR DESCRIPTION
There were failing tests beforehand. These are unrelated.