### PR TITLE
Allow users to set lintr.linter_file

### DIFF
--- a/R/settings.R
+++ b/R/settings.R
@@ -56,6 +56,9 @@ find_config <- function(filename) {
   }
   linter_file <- getOption("lintr.linter_file")
 
+  ## if users changed lintr.linter_file, return immediately.
+  if (is_absolute_path(linter_file) && file.exists(linter_file)) return(linter_file)
+
   path <- if (is_directory(filename)) {
     filename
   } else {


### PR DESCRIPTION
This lets users specify the location of the linter file with
options(lintr.linter_file) before calling lintr::lint(). This should
be useful to allow the various plugins to specify the path to the
.lintr file

Related to #123 and #335