### PR TITLE
Allow passing multiple styles to object_name_linter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # lintr 1.0.2.9000 # 
+* Fixed error when object_name_linter is passed multiple styles (#341, @infotroph)
 * Config files are now also searched for in the users' home directory (#266, @randy3k)
 * Fixed crash caused by ambiguous cache file paths (#212, @fangly).
 * RStudio addins to lint current source and project (fixes #264, @JhossePaul)

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -132,11 +132,11 @@ object_name_linter <- function(style = "snake_case") {
   make_object_linter(
     function(source_file, token) {
       name <- unquote(token[["text"]])
-      if (!matches_styles(name, style)) {
+      if (!any(matches_styles(name, style))) {
         object_lint(
           source_file,
           token,
-          sprintf("Variable or function name should be %s.", style),
+          sprintf("Variable or function name should be %s.", paste(style, collapse = " or ")),
           "object_name_linter"
         )
       }

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -80,7 +80,7 @@ test_that("linter returns correct linting", {
   expect_lint("a(camelCase = 1)", NULL, linter)
 })
 
-test_that("linter accepts vectors of styles", {
+test_that("linter accepts vector of styles", {
   msg <- "Variable or function name should be lowerCamelCase or dotted.case."
   linter <- object_name_linter(style=c("lowerCamelCase", "dotted.case"))
 

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -79,3 +79,14 @@ test_that("linter returns correct linting", {
   expect_lint("pack:::camelCase", NULL, linter)
   expect_lint("a(camelCase = 1)", NULL, linter)
 })
+
+test_that("linter accepts vectors of styles", {
+  msg <- "Variable or function name should be lowerCamelCase or dotted.case."
+  linter <- object_name_linter(style=c("lowerCamelCase", "dotted.case"))
+
+  expect_lint(
+    c("var.one <- 1", "varTwo <- 2", "var_three <- 3"),
+    list(message=msg, line_number=3L, column_number=1L),
+    linter
+  )
+})


### PR DESCRIPTION
Fixes #341. Example usage: ` lint("inst/example/bad.R", object_name_linter(c("dotted.case", "lowerCamelCase"))`
