### PR TITLE
fixes #252: Allow plain-code-blocks in RMarkdown

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -1,3 +1,29 @@
+filter_chunk_end_positions <- function(starts, ends) {
+  # In a valid file, possibly with plain-code-blocks,
+  # - there should be at least as many ends as starts,
+  #   and there should be an even-number of extra ends (possibly zero)
+  #   since each plain-code-block should open & close, and the open/close
+  #   tags of a plain-code-block both match the chunk.end pattern
+
+  # starts (1, 3, 5, 7,        11)  --> (1, 3, 5, 7, 11)
+  # ends   (2, 4, 6, 8, 9, 10, 12)  --> (2, 4, 6, 8, 12) # return this
+  length_difference <- length(ends) - length(starts)
+
+  if(length_difference < 0 | length_difference %% 2 != 0) {
+    stop("Malformed file!", call. = FALSE)
+  }
+  if (length_difference == 0 && all(ends > starts)) {
+    return(ends)
+  }
+
+  positions <- sort(c(starts = starts, ends = ends))
+  code_start_indexes <- which(grepl("starts", names(positions)))
+  code_ends <- positions[1 + code_start_indexes]
+
+  stopifnot(all(grepl("ends", names(code_ends))))
+  code_ends
+}
+
 # content is the file content from readLines
 extract_r_source <- function(filename, lines) {
 
@@ -7,7 +33,10 @@ extract_r_source <- function(filename, lines) {
   }
 
   starts <- grep(pattern$chunk.begin, lines, perl = TRUE)
-  ends <- grep(pattern$chunk.end, lines, perl = TRUE)
+  ends <- filter_chunk_end_positions(
+    starts = starts,
+    ends = grep(pattern$chunk.end, lines, perl = TRUE)
+  )
 
   # no chunks found, so just return the lines
   if (length(starts) == 0 || length(ends) == 0) {

--- a/tests/testthat/knitr_formats/test.Rmd
+++ b/tests/testthat/knitr_formats/test.Rmd
@@ -29,3 +29,8 @@ a=[]
 
 a[0]=1
 ```
+
+```
+Plain code blocks can be written after three or more backticks
+- R Markdown: The Definitive Guide. Xie, Allaire and Grolemund (2.5.2)
+```


### PR DESCRIPTION
Added a test to the end of test.Rmd that included a plain-code-block like this:

```
This shouldn't cause a problem
```

That is, a code-block where the interpreter is not specified (these are allowable in Rmarkdown according to section 2.5.2 of Yihui's Rmarkdown book).

The code-block reproduced the `Malformed File` error described in issue #252

Plain-blocks match the knitr `chunk.end` pattern at both the start and the end
of the chunk. So when plain-blocks are present there was an extra 2k chunk ends
than starts.

A small function `filter_chunk_end_positions` was added to filter the positions
of the chunk-ends based on the chunk-starts and called from `extract_r_source`