### PR TITLE
fixes #322: allows Rmd chunks using {lang} engine format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@
 * Allow for any number of `#` to start a comment. Useful in ESS (#299, @prosoitos)
 * New equals_na_linter() (#143, #326, @jabranham)
 * Fixed plain-code-block bug in Rmarkdown (#252, @russHyde)
+* Fixed bug where non-R chunks using {lang} `engine format` were parsed from R-markdown (#322, @russHyde)
 
 # lintr 1.0.2 #
 * Fix tests to work with upcoming testthat release.

--- a/tests/testthat/knitr_formats/test.Rmd
+++ b/tests/testthat/knitr_formats/test.Rmd
@@ -34,3 +34,19 @@ a[0]=1
 Plain code blocks can be written after three or more backticks
 - R Markdown: The Definitive Guide. Xie, Allaire and Grolemund (2.5.2)
 ```
+
+Calls to a non-R knitr-engine using {engine_name} syntax.
+
+```{python}
+# Python that looks like R
+a = list()
+b = {2}
+print(a)
+```
+
+```{python}
+# Python that's definitely not R
+a = []
+a.append(2)
+print(a)
+```


### PR DESCRIPTION
Rmarkdown format allows the use of code blocks in the following format

~~~~
```{some_engine}
# not necessarily R syntax
foo = bar
```
~~~~

These blocks should be filtered out before linting the remaining R-code blocks.

A couple of python blocks were added to test.Rmd: one with R-like syntax and one with syntax that can't be parsed as R.

The function `defines_knitr_engine` was extracted from `extract_r_source` and extended. This tests for the presence of {r engine = some_engine} and {some_engine} in the start line of a code chunk. The names of valid engines are obtained from `knitr::knit_engines`

An unrelated, cosmetic change to `filter_chunk_end_positions` was made (which(grepl(...)) --> grep(...)).