### PR TITLE
doc update to fix #351

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Suggests:
 License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 Collate: 
     'T_and_F_symbol_linter.R'
     'utils.R'

--- a/R/lint.R
+++ b/R/lint.R
@@ -14,7 +14,7 @@ NULL
 #' Apply one or more linters to a file and return the lints found.
 #' @name lint_file
 #' @param filename the given filename to lint.
-#' @param linters a list of linter functions to apply see \code{\link{linters}}
+#' @param linters a named list of linter functions to apply see \code{\link{linters}}
 #' for a full list of default and available linters.
 #' @param cache given a logical, toggle caching of lint results. If passed a
 #' character string, store the cache in this directory.

--- a/man/lint_file.Rd
+++ b/man/lint_file.Rd
@@ -11,7 +11,7 @@ lint(filename, linters = NULL, cache = FALSE, ...,
 \arguments{
 \item{filename}{the given filename to lint.}
 
-\item{linters}{a list of linter functions to apply see \code{\link{linters}}
+\item{linters}{a named list of linter functions to apply see \code{\link{linters}}
 for a full list of default and available linters.}
 
 \item{cache}{given a logical, toggle caching of lint results. If passed a


### PR DESCRIPTION
just adding that the list of linter functions needs to be named, since that tripped up a few people, see e.g., #351 