### PR TITLE
bump `lintr` version in checkstyle

### DIFF
--- a/tests/testthat/checkstyle.xml
+++ b/tests/testthat/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="lintr-1.0.2.9000">
+<checkstyle version="lintr-1.0.3.9000">
   <file name="test_file">
     <error line="1" column="2" severity="error" message="foo"/>
     <error line="2" column="1" severity="info" message="bar"/>


### PR DESCRIPTION
Mismatching `lintr` versions between the earlier version of the changed file and `checkstyle_output()` threw a testthat error. Ref https://github.com/jimhester/lintr/issues/363