### PR TITLE
allow text-only Rmarkdown files

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -14,7 +14,7 @@ extract_r_source <- function(filename, lines) {
 
   # no chunks found, so just return the lines
   if (length(starts) == 0 || length(ends) == 0) {
-    return(lines)
+    return(character(0))
   }
 
   if (length(starts) != length(ends)) {

--- a/R/extract.R
+++ b/R/extract.R
@@ -12,7 +12,7 @@ extract_r_source <- function(filename, lines) {
     ends = grep(pattern$chunk.end, lines, perl = TRUE)
   )
 
-  # no chunks found, so just return the lines
+  # no chunks found
   if (length(starts) == 0 || length(ends) == 0) {
     return(character(0))
   }

--- a/tests/testthat/knitr_formats/text-only.Rmd
+++ b/tests/testthat/knitr_formats/text-only.Rmd
@@ -1,0 +1,5 @@
+---
+Title: "my_title"
+---
+
+Just text in here at present

--- a/tests/testthat/test-knitr_formats.R
+++ b/tests/testthat/test-knitr_formats.R
@@ -82,3 +82,9 @@ test_that("it does _not_ error with inline \\Sexpr", {
     ),
     default_linters)
 })
+
+test_that("it does not error with text-only R-markdown", {
+  expect_lint(file = "knitr_formats/text-only.Rmd",
+    checks = NULL,
+    default_linters)
+})


### PR DESCRIPTION
added (initially) failing test

- text-only Rmarkdown file should not throw any lints

The original lintr-code threw an `unexpected symbol` lint on an Rmarkdown file
that did not contain any code, because the first sentence was parsed as if
R-code.