### PR TITLE
ensure lintr runs/installs/tests on R-3.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,8 @@ Imports:
 Suggests:
     rmarkdown,
     mockery
+Remotes:
+    r-lib/xmlparsedata
 License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,9 @@
 * New equals_na_linter() (#143, #326, @jabranham)
 * Fixed plain-code-block bug in Rmarkdown (#252, @russHyde)
 * Fixed bug where non-R chunks using {lang} `engine format` were parsed from R-markdown (#322, @russHyde)
+* Ensured `lintr` runs / installs / tests on R-3.6: pinned to github
+  `xmlparsedata`; ensure vectors are length-1 when compared using `&&` and `||`
+  (#363 #377 #384 #391, @russHyde).
 
 # lintr 1.0.3 #
 * Fix tests to work with changes in the parser in R 3.6

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -28,6 +28,7 @@ exclude <- function(lints, exclusions = settings$exclusions, ...) {
     function(i) {
       file <- df$filename[i]
       file %in% names(exclusions) &&
+        length(exclusions[[file]]) == 1 &&
         exclusions[[file]] == Inf ||
         df$line_number[i] %in% exclusions[[file]]
      },

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 `%||%` <- function(x, y) {
-  if (is.null(x) || is.na(x) || length(x) <= 0) {
+  if (is.null(x) || length(x) <= 0 || is.na(x[[1L]])) {
     y
   } else {
     x


### PR DESCRIPTION
The dev version of `xmlparsedata` has been updated to fix a parsing bug on R-3.6; before fixing that bug several lintr tests were failing (https://github.com/jimhester/lintr/issues/384). This change points `lintr` to the dev version of xmlparsedata