### PR TITLE
lint formals and ensure names match >= 1 style

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ License: MIT + file LICENSE
 LazyData: true
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
-Collate: 
+Encoding: UTF-8
+Collate:
     'T_and_F_symbol_linter.R'
     'utils.R'
     'aaa.R'

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -1,5 +1,7 @@
-#' @describeIn linters  Check that object names conform to a single naming style.
-#' @param styles One of \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}.
+#' @describeIn linters  Check that object names conform to a naming style.
+#' @param styles A subset of
+#'   \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
+#'   match at least one of these styles.
 #' @export
 object_name_linter <- function(styles = "snake_case") {
 

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -116,7 +116,9 @@ same line.}
 
 \item{todo}{Vector of strings that identify TODO comments.}
 
-\item{styles}{One of \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}.}
+\item{styles}{A subset of
+\Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should
+match at least one of these styles.}
 
 \item{length}{the length cutoff to use for the given linter.}
 
@@ -153,7 +155,7 @@ blocks
 
 \item \code{todo_comment_linter}: Check that the source contains no TODO comments (case-insensitive).
 
-\item \code{object_name_linter}: Check that object names conform to a single naming style.
+\item \code{object_name_linter}: Check that object names conform to a naming style.
 
 \item \code{object_length_linter}: check that object names are not too long.
 

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -47,7 +47,7 @@ test_that("linter ignores some objects", {
 })
 
 test_that("linter returns correct linting", {
-  msg <- "Variable and function names should be in camelCase."
+  msg <- "Variable and function name style should be camelCase."
   linter <- object_name_linter("camelCase")
 
   expect_lint("myObject <- 123", NULL, linter)
@@ -58,7 +58,7 @@ test_that("linter returns correct linting", {
               list(message=msg, line_number=1L, column_number=1L), linter)
 
   expect_lint(
-    "Z = sapply('function', function(x=function(x){1}, b.a.z=F){identity(b.a.z)}, USE.NAMES=TRUE)",
+    "Z = sapply('function', function(x=function(x){1}, b.a.z=F, ...){identity(b.a.z)}, USE.NAMES=TRUE)",
     list(
       list(message=msg, line_number=1L, column_number=1L),
       list(message=msg, line_number=1L, column_number=51L)
@@ -77,8 +77,8 @@ test_that("linter returns correct linting", {
 })
 
 test_that("linter accepts vector of styles", {
-  msg <- "Variable or function name should be lowerCamelCase or dotted.case."
-  linter <- object_name_linter(style=c("lowerCamelCase", "dotted.case"))
+  msg <- "Variable and function name style should be camelCase or dotted.case."
+  linter <- object_name_linter(styles=c("camelCase", "dotted.case"))
 
   expect_lint(
     c("var.one <- 1", "varTwo <- 2", "var_three <- 3"),


### PR DESCRIPTION
Previous xml-based version of `object_name_linter`:

- required all names to match every one of the requested
  styles

- disregarded names of formals in newly-defined functions

Hence:

- added extra xpath clause to catch `SYMBOL_FORMALS`

- used or-reduction to ensure each name matches at least one
style.

Also:

- since multiple styles are allowed, the lint message is now
  like "Variable and function name style should be style_1,
  style_2 or style_3".

- tests for `object_name_linter` and lint message for
  `object_name_linter_old` were changed to match this
  format.

- added `...` argument to a unit test to ensure that
  `object_name_linter` does not flag dots.