### PR TITLE
Check on multiple r releases

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@
 ^COPYING$
 ^bad\.R$
 ^\.github$
+^codecov\.yml$
+^\.covrignore$

--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,2 @@
+R/deprec-*.R
+R/compat-*.R

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,13 @@ addons:
 
 r_github_packages: jimhester/covr
 
-after_success:
-  - Rscript -e 'covr::codecov()'
+matrix:
+  include:
+  - r: devel
+  - r: release
+    after_success:
+    - Rscript -e 'covr::codecov()'
+  - r: oldrel
+  - r: 3.4
+  - r: 3.3
+  - r: 3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Checks adherence to a given style, syntax errors and possible
     semantic issues.  Supports on the fly checking of R code edited with 'RStudio IDE', 'Emacs',
     'Vim', 'Sublime Text' and 'Atom'.
 Depends:
-    R (>= 3.1.1)
+    R (>= 3.2)
 Imports:
     rex,
     crayon,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -3,10 +3,11 @@ This is a patch release for compatibility with the upcoming testthat release,
 only changes are in test code from the previous release.
 
 ## Test environments
-* local OS X install, R 3.4.1-patched
-* ubuntu 12.04 (on travis-ci), R 3.4.1
-* win-builder (devel and release)
-* rhub
+
+* local: linux-gnu-3.6.1
+* travis: 3.2, 3.3, 3.4, oldrel, release, devel
+* r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
+* win-builder: windows-x86_64-devel
 
 ## R CMD check results
 

--- a/tests/testthat/test-REMOVE_THIS_TEST.R
+++ b/tests/testthat/test-REMOVE_THIS_TEST.R
@@ -1,0 +1,5 @@
+context("Test that all CI builds fail when a failing test is present")
+
+test_that("This test will always fail", {
+  expect_true(FALSE, info = "all CI builds fail on a failing test")
+})

--- a/tests/testthat/test-REMOVE_THIS_TEST.R
+++ b/tests/testthat/test-REMOVE_THIS_TEST.R
@@ -1,5 +1,0 @@
-context("Test that all CI builds fail when a failing test is present")
-
-test_that("This test will always fail", {
-  expect_true(FALSE, info = "all CI builds fail on a failing test")
-})


### PR DESCRIPTION
add matrix of travis R releases (3.2 -> devel)
    
    Used `use_tidy_ci()` to expand the R-releases used during CI tests
    
    - add configs for codecov
    - bump R dependency to R >= 3.2 (since 3.2 is the earliest release
      used in CI; also dependency httr/knitr require R >= 3.2)
    - `use_tidy_ci` modified `cran-comments.md`; I changed the file
      so that R 3.1 wasnt mentioned in the travis section. But, I dont
      really know what is supposed to go in this file.

Note that I've added a failing test just to check that CI fails for all builds before pushing to lintr master