### PR TITLE
Set testthat dependency to 2.2.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     crayon,
     codetools,
     cyclocomp,
-    testthat,
+    testthat (>= 2.2.1),
     digest,
     rstudioapi (>= 0.2),
     httr (>= 1.2.1),


### PR DESCRIPTION
`expect_lint_free` uses testthat::skip_on_covr, which was not introduced into testthat until 2.2.1

https://github.com/jimhester/lintr/blob/38279839efe0f685b281e80a77bcea1b04665f33/R/expect_lint.R#L110