### PR TITLE
fix #426 : match the 'linter' argument in Lint() to the function name

### DIFF
--- a/R/function_left_parentheses.R
+++ b/R/function_left_parentheses.R
@@ -33,7 +33,7 @@ function_left_parentheses_linter <- function(source_file) {
             type = "style",
             message = "Remove spaces before the left parenthesis in a function call.",
             line = line,
-            linter = "function_left_parentheses"
+            linter = "function_left_parentheses_linter"
             )
         }
       }

--- a/tests/testthat/default_linter_testcode.R
+++ b/tests/testthat/default_linter_testcode.R
@@ -1,0 +1,43 @@
+# Each of the default linters should throw at least one lint on this file
+
+# assignment
+# function_left_parentheses
+# closed_curly
+# commas
+# paren_brace
+f = function (x,y = 1){}
+
+# commented_code
+# some <- commented("out code")
+
+# cyclocomp
+# equals_na
+# infix_spaces
+# line_length
+# object_length
+# object_name
+# object_usage
+# open_curly
+someComplicatedFunctionWithALongCameCaseName <- function(x)
+{
+  y <- 1
+	if (1 > 2 && 2 > 3 && 3 > 4 && 4 > 5 && 5*10 > 6 && x == NA) {TRUE} else {FALSE}
+}
+
+# pipe_continuation
+# seq_linter
+# spaces_inside
+x <- 1:10
+x[ 2]
+1:length(x) %>% lapply(function(x) x*2) %>%
+  head()
+
+# single_quotes
+message('single_quotes')
+
+# spaces_left_parentheses
+# trailing_whitespace
+y <- 2 +(1:10)    
+
+# trailing_blank_lines
+

--- a/tests/testthat/test-defaults.R
+++ b/tests/testthat/test-defaults.R
@@ -30,3 +30,28 @@ test_that("settings", {
   expect_gt(length(x), 0L)
   expect_true(all(names(x) != ""))
 })
+
+test_that("linter_names", {
+  # If they throw a Lint() call, the name of the caught linter should match
+  # the name of the linting function
+  test_file <- "default_linter_testcode.R"
+  x <- default_linters
+  for (linter_name in names(x)) {
+    lints <- lint(test_file, linters = x[linter_name])
+    lint_df <- as.data.frame(lints)
+    expect_true(
+      nrow(lint_df) > 0,
+      info = paste(
+        "each default linter should throw a lint on",
+        "'default_linter_testcode.R'"
+      )
+    )
+    expect_equal(
+      lint_df[["linter"]][1], linter_name,
+      info = paste(
+        "the 'linter' name reported by lint() / Lint() should match the",
+        "name of the corresponding linting function"
+      )
+    )
+  }
+})

--- a/vignettes/creating_linters.Rmd
+++ b/vignettes/creating_linters.Rmd
@@ -25,7 +25,8 @@ assignment_linter <- function(source_file) {
         column_number = parsed$col1,
         type = "style",
         message = "Use <-, not =, for assignment.",
-        line = source_file$lines[parsed$line1]
+        line = source_file$lines[parsed$line1],
+        linter = "assignment_linter"
         )
     })
 }
@@ -81,7 +82,8 @@ Lint(
   column_number = parsed$col1,
   type = "style",
   message = "Use <-, not =, for assignment.",
-  line = source_file$lines[parsed$line1]
+  line = source_file$lines[parsed$line1],
+  linter = "assignment_linter"
   )
 ```
 


### PR DESCRIPTION
When Lint() finds a lint, the name of the 'linter' responsible
(ie, the 'linter' argument to Lint()) should match the name of the linting function.
    
For `function_left_parentheses_linter` this was not the case and this
mismatch has now been fixed
    
For all other linting functions, the reported linter name matches the
function name.

A test was added to ensure that the 'linter' field reported by lint() matches the linting-function's name for each default linter (happy to remove if you think this might become a flaky test).

The 'linter' argument to Lint() was added to the `assignment_linter` example in the vignette.