### PR TITLE
fix #432 - Object usage line numbers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # lintr (development version)
 
+* `object_usage_linter` has been changed to ensure lint-position is indicated
+  relative to the start of the file, rather than the start of a defining
+  function (#432, @russHyde)
+
 # lintr 2.0.0
 
 lintr 2.0.0 is a major release, and incorporates development changes since the last major release (1.0.0) in 2016-04-16.

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -73,7 +73,7 @@ object_usage_linter <-  function(source_file) {
 
         Lint(
           filename = source_file$filename,
-          line_number = row$line_number,
+          line_number = org_line_num,
           column_number = location$start,
           type = "warning",
           message = row$message,

--- a/tests/testthat/test-knitr_formats.R
+++ b/tests/testthat/test-knitr_formats.R
@@ -12,10 +12,10 @@ test_that("it handles dir", {
 test_that("it handles markdown", {
   expect_lint(file = "knitr_formats/test.Rmd",
     checks = list(
-      rex("local variable"),
-      rex("Use <-, not =, for assignment."),
-      rex("Use <-, not =, for assignment."),
-      rex("Trailing blank lines are superfluous.")
+      list(rex("Use <-, not =, for assignment."), line_number = 9),
+      list(rex("local variable"), line_number = 22),
+      list(rex("Use <-, not =, for assignment."), line_number = 22),
+      list(rex("Trailing blank lines are superfluous."), line_number = 24)
     ),
     default_linters
   )
@@ -23,10 +23,10 @@ test_that("it handles markdown", {
 test_that("it handles Sweave", {
   expect_lint(file = "knitr_formats/test.Rnw",
     checks = list(
-      rex("local variable"),
-      rex("Use <-, not =, for assignment."),
-      rex("Use <-, not =, for assignment."),
-      rex("Trailing blank lines are superfluous.")
+      list(rex("Use <-, not =, for assignment."), line_number = 12),
+      list(rex("local variable"), line_number = 24),
+      list(rex("Use <-, not =, for assignment."), line_number = 24),
+      list(rex("Trailing blank lines are superfluous."), line_number = 26)
     ),
     default_linters
   )
@@ -34,10 +34,10 @@ test_that("it handles Sweave", {
 test_that("it handles reStructuredText", {
   expect_lint(file = "knitr_formats/test.Rrst",
     checks = list(
-      rex("local variable"),
-      rex("Use <-, not =, for assignment."),
-      rex("Use <-, not =, for assignment."),
-      rex("Trailing blank lines are superfluous.")
+      list(rex("Use <-, not =, for assignment."), line_number = 10),
+      list(rex("local variable"), line_number = 23),
+      list(rex("Use <-, not =, for assignment."), line_number = 23),
+      list(rex("Trailing blank lines are superfluous."), line_number = 25)
     ),
     default_linters
   )
@@ -45,10 +45,10 @@ test_that("it handles reStructuredText", {
 test_that("it handles HTML", {
   expect_lint(file = "knitr_formats/test.Rhtml",
     checks = list(
-      rex("local variable"),
-      rex("Use <-, not =, for assignment."),
-      rex("Use <-, not =, for assignment."),
-      rex("Trailing blank lines are superfluous.")
+      list(rex("Use <-, not =, for assignment."), line_number = 15),
+      list(rex("local variable"), line_number = 27),
+      list(rex("Use <-, not =, for assignment."), line_number = 27),
+      list(rex("Trailing blank lines are superfluous."), line_number = 29)
     ),
     default_linters
   )
@@ -56,10 +56,10 @@ test_that("it handles HTML", {
 test_that("it handles tex", {
   expect_lint(file = "knitr_formats/test.Rtex",
     checks = list(
-      rex("local variable"),
-      rex("Use <-, not =, for assignment."),
-      rex("Use <-, not =, for assignment."),
-      rex("Trailing blank lines are superfluous.")
+      list(rex("Use <-, not =, for assignment."), line_number = 11),
+      list(rex("local variable"), line_number = 23),
+      list(rex("Use <-, not =, for assignment."), line_number = 23),
+      list(rex("Trailing blank lines are superfluous."), line_number = 25)
     ),
     default_linters
   )
@@ -67,10 +67,10 @@ test_that("it handles tex", {
 test_that("it handles asciidoc", {
   expect_lint(file = "knitr_formats/test.Rtxt",
     checks = list(
-      rex("local variable"),
-      rex("Use <-, not =, for assignment."),
-      rex("Use <-, not =, for assignment."),
-      rex("Trailing blank lines are superfluous.")
+      list(rex("Use <-, not =, for assignment."), line_number = 9),
+      list(rex("local variable"), line_number = 22),
+      list(rex("Use <-, not =, for assignment."), line_number = 22),
+      list(rex("Trailing blank lines are superfluous."), line_number = 24)
     ),
     default_linters
   )

--- a/tests/testthat/test-object_usage_linter.R
+++ b/tests/testthat/test-object_usage_linter.R
@@ -103,3 +103,16 @@ test_that("calls with top level function definitions are ignored", {
     NULL,
     object_usage_linter)
 })
+
+test_that("object-usage line-numbers are relative to start-of-file", {
+  expect_lint(
+"a <- function(y) {
+  y ** 2
+}
+b <- function() {
+  x
+}
+",
+  list(line_number = 5L),
+  object_usage_linter)
+})


### PR DESCRIPTION
In #432 it was noted that the line-number for object-usage-linter
warnings were often incorrect. They were being reported relative to the
start of the defining function, rather than the start of the file.
    
    - A test was added that throws an object-usage-lint on line-2 of the
    function but line-5 of the file.

    - Modified object-usage-linter.R so that it reported the line-number from the original file, rather than the line-number of the encasing function

This led to several of the knitr-format tests failing because lints were throwing in a different order. The original tests were misordered , and have been modified.

Briefly: 
Each of the knitr-format tests had code blocks that look like this:
    
    ~~~~
    a = 1
    ~~~~
    
    ~~~~
    b <- function(x) {
      d = 1
    }
    
    ~~~~
    
    The lints should be ordered:
    - assignment (`=` for a)
    - local variable ‘d’ assigned but may not be used
    - assignment (`=` for d)
    - trailing blank line
    
    I updated the tests and added the explicit line-numbers where the lints
    should throw to test-knitr_formats.R