### PR TITLE
fix #433 : Double quotes in path linters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
 # lintr (development version)
 
+* `absolute_path_linter()` and `nonportable_path_linter()` now handle
+  file-paths that are wrapped with double-quotes (#433, #437, @russHyde).
 * `object_usage_linter` has been changed to ensure lint-position is indicated
   relative to the start of the file, rather than the start of a defining
-  function (#432, @russHyde)
+  function (#432, @russHyde).
 
 # lintr 2.0.0
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -174,3 +174,39 @@ try_silently <- function(expr) {
 
 viapply <- function(x, ...) vapply(x, ..., FUN.VALUE = integer(1))
 vcapply <- function(x, ...) vapply(x, ..., FUN.VALUE = character(1))
+
+unquote <- function(str, q="`") {
+  # Remove surrounding quotes (select either single, double or backtick) from given character vector
+  # and unescape special characters.
+  str <- re_substitutes(str, rex(start, q, capture(anything), q, end), "\\1")
+  unescape(str, q)
+}
+
+escape_chars <- c(
+  "\\\\" = "\\",  # backslash
+  "\\n"  = "\n",  # newline
+  "\\r"  = "\r",  # carriage return
+  "\\t"  = "\t",  # tab
+  "\\b"  = "\b",  # backspace
+  "\\a"  = "\a",  # alert (bell)
+  "\\f"  = "\f",  # form feed
+  "\\v"  = "\v"   # vertical tab
+  # dynamically-added:
+  #"\\'"  = "'",  # ASCII apostrophe
+  #"\\\"" = "\"", # ASCII quotation mark
+  #"\\`"  = "`"   # ASCII grave accent (backtick)
+)
+
+unescape <- function(str, q="`") {
+  names(q) <- paste0("\\", q)
+  my_escape_chars <- c(escape_chars, q)
+  res <- gregexpr(text=str, pattern=rex(or(names(my_escape_chars))))
+  all_matches <- regmatches(str, res)
+  regmatches(str, res) <- lapply(
+    all_matches,
+    function(string_matches) {
+      my_escape_chars[string_matches]
+    }
+  )
+  str
+}

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,4 @@
+# Helpers for lintr tests
+
+single_quote <- function(x) paste0("'", x, "'")
+double_quote <- function(x) paste0('"', x, '"')

--- a/tests/testthat/test-absolute_path_linter.R
+++ b/tests/testthat/test-absolute_path_linter.R
@@ -161,25 +161,44 @@ test_that("returns the correct linting", {
 
   # strict mode
   linter <- absolute_path_linter(lax=FALSE)
-  expect_lint("'..'", NULL, linter)
-  expect_lint("'./blah'", NULL, linter)
-  expect_lint(encodeString("'blah\\file.txt'"), NULL, linter)
-  expect_lint("\"'/'\"", NULL, linter)
+  non_absolute_path_strings <- c(
+    "..",
+    "./blah",
+    encodeString("blah\\file.txt")
+  )
+  for(path in non_absolute_path_strings) {
+    expect_lint(single_quote(path), NULL, linter)
+    expect_lint(double_quote(path), NULL, linter)
+  }
 
-  expect_lint("'/'", msg, linter)
-  expect_lint("'/blah/file.txt'", msg, linter)
-  expect_lint(encodeString("'d:\\'"), msg, linter)
-  expect_lint("'E:/blah/file.txt'", msg, linter)
-  expect_lint(encodeString("'\\\\'"), msg, linter)
-  expect_lint(encodeString("'\\\\server\\path'"), msg, linter)
-  expect_lint("'~'", msg, linter)
-  expect_lint("'~james.hester/blah/file.txt'", msg, linter)
-  expect_lint(encodeString("'/a\nsdf'"), msg, linter)
-  expect_lint("'/as:df'", msg, linter)
+  expect_lint("\"'/'\"", NULL, linter) # nested quotes
+
+  absolute_path_strings <- c(
+    "/",
+    "/blah/file.txt",
+    encodeString("d:\\"),
+    "E:/blah/file.txt",
+    encodeString("\\\\"),
+    encodeString("\\\\server\\path"),
+    "~",
+    "~james.hester/blah/file.txt",
+    encodeString("/a\nsdf"),
+    "/as:df"
+  )
+  for (path in absolute_path_strings) {
+    expect_lint(single_quote(path), msg, linter)
+    expect_lint(double_quote(path), msg, linter)
+  }
 
   # lax mode: no check for strings that are likely not paths (too short or with special characters)
   linter <- absolute_path_linter(lax=TRUE)
-  expect_lint("'/'", NULL, linter)
-  expect_lint(encodeString("'/a\nsdf/bar'"), NULL, linter)
-  expect_lint("'/as:df/bar'", NULL, linter)
+  unlikely_path_strings <- c(
+    "/",
+    encodeString("/a\nsdf/bar"),
+    "/as:df/bar"
+  )
+  for (path in unlikely_path_strings) {
+    expect_lint(single_quote(path), NULL, linter)
+    expect_lint(double_quote(path), NULL, linter)
+  }
 })

--- a/tests/testthat/test-nonportable_path_linter.R
+++ b/tests/testthat/test-nonportable_path_linter.R
@@ -6,34 +6,51 @@ test_that("Non-portable path linter", {
   msg <- rex::escape("Use file.path() to construct portable file paths.")
 
   # various strings
-  expect_lint("'foo'", NULL, linter)
-  expect_lint("'https://cran.r-project.org/web/packages/lintr/'", NULL, linter)
-  expect_lint(encodeString("'hello\nthere!'"), NULL, linter)
-  expect_lint("\"'/foo'\"", NULL, linter)
+  non_path_strings <- c(
+    "foo",
+    "https://cran.r-project.org/web/packages/lintr/",
+    encodeString("hello\nthere!")
+  )
+  for (path in non_path_strings) {
+    expect_lint(single_quote(path), NULL, linter)
+    expect_lint(double_quote(path), NULL, linter)
+  }
+
+  expect_lint("\"'/foo'\"", NULL, linter) # nested quotes
 
   # system root
-  expect_lint("'/'", NULL, linter)
-  expect_lint("'~'", NULL, linter)
-  expect_lint("'c:'", NULL, linter)
-  expect_lint("'.'", NULL, linter)
+  root_path_strings <- c("/", "~", "c:", ".")
+  for (path in root_path_strings) {
+    expect_lint(single_quote(path), NULL, linter)
+    expect_lint(double_quote(path), NULL, linter)
+  }
 
   # paths with (back)slashes
-  expect_lint("'~/'", msg, linter)
-  expect_lint("'c:/'", msg, linter)
-  expect_lint(encodeString("'D:\\'"), msg, linter)
-  expect_lint("'../'", msg, linter)
-  expect_lint("'/foo'", msg, linter)
-  expect_lint("'foo/'", msg, linter)
-  expect_lint("'foo/bar'", msg, linter)
-  expect_lint(encodeString("'foo\\bar'"), msg, linter)
-
-  expect_lint("'/as:df'", msg, linter)
-  expect_lint(encodeString("'/a\nsdf'"), msg, linter)
+  slash_path_strings <- c(
+    "~/",
+    "c:/",
+    encodeString("D:\\"),
+    "../",
+    "/foo",
+    "foo/",
+    "foo/bar",
+    encodeString("foo\\bar"),
+    "/as:df",
+    encodeString("/a\nsdf")
+  )
+  for (path in slash_path_strings) {
+    expect_lint(single_quote(path), msg, linter)
+    expect_lint(double_quote(path), msg, linter)
+  }
 
   # lax mode: no check for strings that are likely not paths (too short or with special characters)
   linter <- nonportable_path_linter(lax=TRUE)
 
-  expect_lint("'/foo'", NULL, linter)
-  expect_lint(encodeString("'/a\nsdf/bar'"), NULL, linter)
-  expect_lint("'/as:df/bar'", NULL, linter)
+  unlikely_path_strings <- c(
+    "/foo", encodeString("/a\nsdf/bar"), "/as:df/bar"
+  )
+  for (path in unlikely_path_strings) {
+    expect_lint(single_quote(path), NULL, linter)
+    expect_lint(double_quote(path), NULL, linter)
+  }
 })


### PR DESCRIPTION
In issue #433 , filepaths that were surrounded with double-quotes were immune to the absolute-path-linter. This issue also affected the nonportable path linter.

Here, 

- some tests were added to ensure that double-quoted filepaths are linted by the path-linters.
- `absolute_path_linter` and `nonportable_path_linter` were refactored to place any duplicated logic in a function-builder (`make_path_linter`)
- strings that are surrounded by double (single, respectively) quotes were stripped of the surrounding double quotes and then the remaining double quotes were unescaped
- (outdated; unquote has not been modified) The latter change was achieved by modifying `unquote` to accept a vector of quote-characters;
- The change was achieved by getting the path-linter to select the appropriate quote-character before calling `unquote` (see below)

`unquote` is also called by some functions in `object_name_linter.R` (but defined in path_linter.R)
- hence `unquote` and some related functions were moved to utils.R