### PR TITLE
Fix the parsing of source-expressions on R-devel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * `object_usage_linter` has been changed to ensure lint-position is indicated
   relative to the start of the file, rather than the start of a defining
   function (#432, @russHyde).
+* `get_source_expressions` has been changed to handle `expr_or_assign_or_help`
+  tokens arising when parsing code containing equals-assignments in R-devel
+  (#403, #456, @russHyde).
 
 # lintr 2.0.0
 

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -10,7 +10,6 @@ get_source_expressions <- function(filename) {
   source_file$content <- get_content(source_file$lines)
 
   lint_error <- function(e) {
-
     message_info <- re_matches(e$message,
       rex(except_some_of(":"),
         ":",
@@ -72,37 +71,21 @@ get_source_expressions <- function(filename) {
       message = message_info$message,
       line = line,
       linter = "error"
-      )
+    )
   }
 
   e <- NULL
-
   parsed_content <- get_source_file(source_file, error = lint_error)
   tree <- generate_tree(parsed_content)
 
-  expressions <- lapply(top_level_expressions(parsed_content), function(loc) {
-    line_nums <- parsed_content$line1[loc]:parsed_content$line2[loc]
-    expr_lines <- source_file$lines[line_nums]
-    names(expr_lines) <- line_nums
-    content <- get_content(expr_lines, parsed_content[loc, ])
-
-    id <- as.character(parsed_content$id[loc])
-    edges <- component_edges(tree, id)
-    pc <- parsed_content[c(loc, edges), ]
-    list(
-      filename = filename,
-      line = parsed_content[loc, "line1"],
-      column = parsed_content[loc, "col1"],
-      lines = expr_lines,
-      parsed_content = pc,
-      xml_parsed_content = xml2::read_xml(xmlparsedata::xml_parse_data(pc)),
-      content = content,
-
-      find_line = find_line_fun(content),
-
-      find_column = find_column_fun(content)
-      )
-    })
+  expressions <- lapply(
+    X = top_level_expressions(parsed_content),
+    FUN = get_single_source_expression,
+    parsed_content,
+    source_file,
+    filename,
+    tree
+  )
 
   # add global expression
   expressions[[length(expressions) + 1L]] <-
@@ -115,6 +98,32 @@ get_source_expressions <- function(filename) {
     )
 
   list(expressions = expressions, error = e, lines = source_file$lines)
+}
+
+get_single_source_expression <- function(loc,
+                                         parsed_content,
+                                         source_file,
+                                         filename,
+                                         tree) {
+  line_nums <- parsed_content$line1[loc]:parsed_content$line2[loc]
+  expr_lines <- source_file$lines[line_nums]
+  names(expr_lines) <- line_nums
+  content <- get_content(expr_lines, parsed_content[loc, ])
+
+  id <- as.character(parsed_content$id[loc])
+  edges <- component_edges(tree, id)
+  pc <- parsed_content[c(loc, edges), ]
+  list(
+    filename = filename,
+    line = parsed_content[loc, "line1"],
+    column = parsed_content[loc, "col1"],
+    lines = expr_lines,
+    parsed_content = pc,
+    xml_parsed_content = xml2::read_xml(xmlparsedata::xml_parse_data(pc)),
+    content = content,
+    find_line = find_line_fun(content),
+    find_column = find_column_fun(content)
+  )
 }
 
 get_source_file <- function(source_file, error = identity) {
@@ -280,7 +289,8 @@ fix_eq_assigns <- function(pc) {
   }
 
   eq_assign_locs <- which(pc$token == "EQ_ASSIGN")
-  if (length(eq_assign_locs) == 0L || "equal_assign" %in% pc$token) {
+  if (length(eq_assign_locs) == 0L ||
+    any(c("equal_assign", "expr_or_assign_or_help") %in% pc$token)) {
     return(pc)
   }
 


### PR DESCRIPTION
The parsed_content generated in R-devel (to be R4.0) uses a token `expr_or_assign_or_help` in the same way that R3.6 used `equal_assign`. Parsing code with equals-assignments caused problems when running lintr on R-devel for this repo (see #403 ): https://github.com/csgillespie/poweRlaw/commit/ede33811f79376cb0a4ca29f8b0972a8b8b35910 

The existing `lintr` code had a function `fix_eq_assigns` that handled `equal_assign`; this PR just extends that code to handle `expr_or_assign_or_help` in the same way.

To work out what was going on, I extracted the contents of an lapply loop(in `get_source_expressions`) into a stand-alone function `get_single_source_expression` to aid debugging.