### PR TITLE
lintr:::print.lint issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # lintr (development version)
-
+* `single_quote_linter()` no longer causes a print issue when open quote 
+  appears at a column > than close quote (@jamieRowen)
 * `absolute_path_linter()` and `nonportable_path_linter()` now handle
   file-paths that are wrapped with double-quotes (#433, #437, @russHyde).
 * `object_usage_linter` has been changed to ensure lint-position is indicated

--- a/R/single_quotes_linter.R
+++ b/R/single_quotes_linter.R
@@ -13,7 +13,7 @@ single_quotes_linter <- function(source_file) {
           type = "style",
           message = "Only use double-quotes.",
           line = source_file$lines[as.character(parsed$line1)],
-          ranges = list(c(parsed$col1, parsed$col2)),
+          ranges = list(sort(c(parsed$col1, parsed$col2))),
           linter = "single_quotes_linter"
           )
       }

--- a/tests/testthat/test-single_quotes_linter.R
+++ b/tests/testthat/test-single_quotes_linter.R
@@ -26,4 +26,10 @@ test_that("returns the correct linting", {
   expect_lint("{'blah'}",
     rex("Only use double-quotes."),
     single_quotes_linter)
+
+  expect_lint("
+    x = 'test
+    '",
+    rex("Only use double-quotes."),
+    single_quotes_linter)
 })


### PR DESCRIPTION
fixed an issue that caused a
Error in rep.int(character, length) : invalid 'times' value
that caused an issue when printing results from the single_quotes_lintr
It was assumed in highlight_string that the range was such that
range[1] < range[2] which is not necessarily the case when
the string is split over a new line. Added a test case for this
too.