### PR TITLE
Fix fix_eq_assigns with last token being EQ_ASSIGN

### DIFF
--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -290,6 +290,7 @@ fix_eq_assigns <- function(pc) {
 
   eq_assign_locs <- which(pc$token == "EQ_ASSIGN")
   if (length(eq_assign_locs) == 0L ||
+    length(pc$token) %in% eq_assign_locs ||
     any(c("equal_assign", "expr_or_assign_or_help") %in% pc$token)) {
     return(pc)
   }

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -290,7 +290,7 @@ fix_eq_assigns <- function(pc) {
 
   eq_assign_locs <- which(pc$token == "EQ_ASSIGN")
   if (length(eq_assign_locs) == 0L ||
-    length(pc$token) %in% eq_assign_locs ||
+    nrow(pc) %in% eq_assign_locs || # check whether the equal-assignment is the final entry
     any(c("equal_assign", "expr_or_assign_or_help") %in% pc$token)) {
     return(pc)
   }

--- a/tests/testthat/test-commas_linter.R
+++ b/tests/testthat/test-commas_linter.R
@@ -43,8 +43,4 @@ test_that("returns the correct linting", {
   expect_lint("a[1, , 2, , 3]",
     NULL,
     commas_linter)
-
-  expect_lint("purrr::partial(list, 1, ... = , 2)",
-    rex("Commas should never have a space before."),
-    commas_linter)
 })

--- a/tests/testthat/test-commas_linter.R
+++ b/tests/testthat/test-commas_linter.R
@@ -43,4 +43,8 @@ test_that("returns the correct linting", {
   expect_lint("a[1, , 2, , 3]",
     NULL,
     commas_linter)
+  
+  expect_lint("purrr::partial(list, 1, ... = , 2)\n",
+    rex("Commas should never have a space before."),
+    commas_linter)
 })

--- a/tests/testthat/test-commas_linter.R
+++ b/tests/testthat/test-commas_linter.R
@@ -43,8 +43,8 @@ test_that("returns the correct linting", {
   expect_lint("a[1, , 2, , 3]",
     NULL,
     commas_linter)
-  
-  expect_lint("purrr::partial(list, 1, ... = , 2)\n",
+
+  expect_lint("purrr::partial(list, 1, ... = , 2)",
     rex("Commas should never have a space before."),
     commas_linter)
 })

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -16,10 +16,16 @@ test_that("returns the correct linting", {
     b",
     rex("unexpected end of input"), (function(...) NULL))
 
-  expect_lint("x=\n",
-    rex("unexpected end of input")
+  expect_lint("x=",
+    list(
+      rex("Use <-, not =, for assignment"),
+      rex("unexpected end of input")
     )
-  expect_lint("sum(1:10, na.rm += 1)\n",
-    rex("unexpected '='")
+  )
+  expect_lint("x += 1",
+    list(
+      rex("Use <-, not =, for assignment"),
+      rex("unexpected '='")
     )
+  )
 })

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -17,15 +17,25 @@ test_that("returns the correct linting", {
     rex("unexpected end of input"), (function(...) NULL))
 
   expect_lint("x=",
-    list(
-      rex("Use <-, not =, for assignment"),
-      rex("unexpected end of input")
-    )
+    rex("unexpected end of input"),
+    equals_na_linter
   )
   expect_lint("x += 1",
-    list(
-      rex("Use <-, not =, for assignment"),
-      rex("unexpected '='")
-    )
+    rex("unexpected '='"),
+    equals_na_linter
+  )
+  expect_lint("{x = }",
+    rex("unexpected '}'"),
+    equals_na_linter
+  )
+  expect_lint("x = ;",
+    rex("unexpected ';'"),
+    equals_na_linter
+  )
+
+  # no parsing error is expected for the equals-assignment in this code
+  expect_lint("purrr::partial(list, 1, ... = , 2)",
+    NULL,
+    equals_na_linter
   )
 })

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -15,4 +15,11 @@ test_that("returns the correct linting", {
     function() {
     b",
     rex("unexpected end of input"), (function(...) NULL))
+
+  expect_lint("x=\n",
+    rex("unexpected end of input")
+    )
+  expect_lint("sum(1:10, na.rm += 1)\n",
+    rex("unexpected '='")
+    )
 })


### PR DESCRIPTION
Closes #461 

This PR fixes the handling of source code such as 

```r
x=
```

```r
sum(1:10, na.rm += 1)
```

for which the parse data stops at the `=` in these cases where the last token is always `EQ_ASSIGN`. This PR adds a condition that if the last token is `EQ_ASSIGN` then `fix_eq_assigns` should not do anything because `next_with_parent` no longer works.