### PR TITLE
Fix #472: Allow non-evaluated code blocks with markdown format-specifier

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lintr
 Title: A 'Linter' for R Code
-Version: 2.0.1
+Version: 2.0.1.9000
 Authors@R: c(
     person("Jim", "Hester", email = "james.f.hester@gmail.com", role = c("aut", "cre")),
     person("Florent", "Angly", role = "aut"),
@@ -35,7 +35,7 @@ License: MIT + file LICENSE
 LazyData: true
 Encoding: UTF-8
 VignetteBuilder: knitr
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0
 Collate:
     'T_and_F_symbol_linter.R'
     'utils.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# lintr (development version)
+
+* `extract_r_source` handles Rmd containing unevaluated code blocks with named
+  format specifiers (#472, @russHyde)
+
 # lintr 2.0.1
 
 ## New features

--- a/R/extract.R
+++ b/R/extract.R
@@ -12,10 +12,6 @@ extract_r_source <- function(filename, lines) {
     return(character())
   }
 
-  if (length(chunks[["starts"]]) != length(chunks[["ends"]])) {
-    stop("Malformed file!", call. = FALSE)
-  }
-
   # there is no need to worry about the lines after the last chunk end
   output <- rep.int(NA_character_, max(chunks[["ends"]] - 1))
   Map(
@@ -53,6 +49,7 @@ get_chunk_positions <- function(pattern, lines) {
 }
 
 filter_chunk_start_positions <- function(starts, lines) {
+  # keep blocks that don't set a knitr engine (and so contain evaluated R code)
   drop <- defines_knitr_engine(lines[starts])
   starts[!drop]
 }
@@ -69,6 +66,9 @@ filter_chunk_end_positions <- function(starts, ends) {
   length_difference <- length(ends) - length(starts)
   if (length_difference == 0 && all(ends > starts)) {
     return(ends)
+  }
+  if (length_difference < 0) {
+    stop("Malformed file!", call. = FALSE)
   }
 
   positions <- sort(c(starts = starts, ends = ends))

--- a/R/extract.R
+++ b/R/extract.R
@@ -6,36 +6,26 @@ extract_r_source <- function(filename, lines) {
     return(lines)
   }
 
-  starts <- grep(pattern$chunk.begin, lines, perl = TRUE)
-  ends <- filter_chunk_end_positions(
-    starts = starts,
-    ends = grep(pattern$chunk.end, lines, perl = TRUE)
-  )
+  chunks <- get_chunk_positions(pattern = pattern, lines = lines)
 
   # no chunks found, so just return the lines
-  if (length(starts) == 0 || length(ends) == 0) {
+  if (length(chunks[["starts"]]) == 0 || length(chunks[["ends"]]) == 0) {
     return(character())
   }
 
-  if (length(starts) != length(ends)) {
+  if (length(chunks[["starts"]]) != length(chunks[["ends"]])) {
     stop("Malformed file!", call. = FALSE)
   }
 
   # there is no need to worry about the lines after the last chunk end
-  output <- rep.int(NA_character_, max(ends - 1))
+  output <- rep.int(NA_character_, max(chunks[["ends"]] - 1))
   Map(
     function(start, end) {
-      if (
-        # block contains at least one line of code
-        start + 1 < end &&
-
-        # block does not set an engine (so is r code)
-        !defines_knitr_engine(lines[start])
-      ) {
-        output[seq(start + 1, end - 1)] <<- lines[seq(start + 1, end - 1)]
-      }
+      output[seq(start + 1, end - 1)] <<- lines[seq(start + 1, end - 1)]
     },
-    starts, ends)
+    chunks[["starts"]],
+    chunks[["ends"]]
+  )
   replace_prefix(output, pattern$chunk.code)
 }
 
@@ -48,20 +38,36 @@ get_knitr_pattern <- function(filename, lines) {
   }
 }
 
+get_chunk_positions <- function(pattern, lines) {
+  starts <- filter_chunk_start_positions(
+    starts = grep(pattern$chunk.begin, lines, perl = TRUE),
+    lines = lines
+  )
+  ends <- filter_chunk_end_positions(
+    starts = starts,
+    ends = grep(pattern$chunk.end, lines, perl = TRUE)
+  )
+  # only keep those blocks that contain at least one line of code
+  keep <- which(ends - starts > 1)
+
+  list(starts = starts[keep], ends = ends[keep])
+}
+
+filter_chunk_start_positions <- function(starts, lines) {
+  drop <- defines_knitr_engine(lines[starts])
+  starts[!drop]
+}
+
 filter_chunk_end_positions <- function(starts, ends) {
   # In a valid file, possibly with plain-code-blocks,
-  # - there should be at least as many ends as starts,
-  #   and there should be an even-number of extra ends (possibly zero)
-  #   since each plain-code-block should open & close, and the open/close
-  #   tags of a plain-code-block both match the chunk.end pattern
+  # - there should be at least as many ends as starts
+  # In Rmarkdown, unevaluated blocks may open & close with the same ``` pattern
+  # that defines the end-pattern for an evaluated block
 
+  # This returns the first end-position that succeeds each start-position
   # starts (1, 3, 5, 7,        11)  --> (1, 3, 5, 7, 11)
   # ends   (2, 4, 6, 8, 9, 10, 12)  --> (2, 4, 6, 8, 12) # return this
   length_difference <- length(ends) - length(starts)
-
-  if(length_difference < 0 | length_difference %% 2 != 0) {
-    stop("Malformed file!", call. = FALSE)
-  }
   if (length_difference == 0 && all(ends > starts)) {
     return(ends)
   }
@@ -74,7 +80,7 @@ filter_chunk_end_positions <- function(starts, ends) {
   code_ends
 }
 
-defines_knitr_engine <- function(line) {
+defines_knitr_engine <- function(start_lines) {
   engines <- names(knitr::knit_engines$get())
 
   # {some_engine}, {some_engine label, ...} or {some_engine, ...}
@@ -86,8 +92,8 @@ defines_knitr_engine <- function(line) {
     boundary, "engine", any_spaces, "="
   )
 
-  rex::re_matches(line, explicit_engine_pattern) ||
-  rex::re_matches(line, bare_engine_pattern)
+  rex::re_matches(start_lines, explicit_engine_pattern) |
+  rex::re_matches(start_lines, bare_engine_pattern)
 }
 
 replace_prefix <- function(lines, prefix_pattern) {

--- a/R/extract.R
+++ b/R/extract.R
@@ -1,6 +1,5 @@
 # content is the file content from readLines
 extract_r_source <- function(filename, lines) {
-
   pattern <- get_knitr_pattern(filename, lines)
   if (is.null(pattern$chunk.begin) || is.null(pattern$chunk.end)) {
     return(lines)
@@ -30,7 +29,7 @@ extract_r_source <- function(filename, lines) {
 }
 
 get_knitr_pattern <- function(filename, lines) {
-  pattern <- ("knitr" %:::% "detect_pattern")(lines, tolower( ("knitr" %:::% "file_ext")(filename)))
+  pattern <- ("knitr" %:::% "detect_pattern")(lines, tolower(("knitr" %:::% "file_ext")(filename)))
   if (!is.null(pattern)) {
     knitr::all_patterns[[pattern]]
   } else {
@@ -93,7 +92,7 @@ defines_knitr_engine <- function(start_lines) {
   )
 
   rex::re_matches(start_lines, explicit_engine_pattern) |
-  rex::re_matches(start_lines, bare_engine_pattern)
+    rex::re_matches(start_lines, bare_engine_pattern)
 }
 
 replace_prefix <- function(lines, prefix_pattern) {
@@ -106,7 +105,9 @@ replace_prefix <- function(lines, prefix_pattern) {
 
   blanks <- function(n) {
     vapply(Map(rep.int, rep.int(" ", length(n)), n, USE.NAMES = FALSE),
-      paste, "", collapse = "")
+      paste, "",
+      collapse = ""
+    )
   }
 
   regmatches(lines[non_na], m[non_na]) <-

--- a/man/default_linters.Rd
+++ b/man/default_linters.Rd
@@ -4,7 +4,9 @@
 \name{default_linters}
 \alias{default_linters}
 \title{Default linters}
-\format{An object of class \code{list} of length 22.}
+\format{
+An object of class \code{list} of length 22.
+}
 \usage{
 default_linters
 }

--- a/man/default_settings.Rd
+++ b/man/default_settings.Rd
@@ -4,7 +4,9 @@
 \name{default_settings}
 \alias{default_settings}
 \title{Default lintr settings}
-\format{An object of class \code{list} of length 9.}
+\format{
+An object of class \code{list} of length 9.
+}
 \usage{
 default_settings
 }

--- a/man/default_undesirable_functions.Rd
+++ b/man/default_undesirable_functions.Rd
@@ -7,7 +7,15 @@
 \alias{all_undesirable_operators}
 \alias{default_undesirable_operators}
 \title{Default undesirable functions and operators}
-\format{A named list of character strings.}
+\format{
+A named list of character strings.
+
+An object of class \code{list} of length 14.
+
+An object of class \code{list} of length 3.
+
+An object of class \code{list} of length 3.
+}
 \usage{
 all_undesirable_functions
 

--- a/tests/testthat/checkstyle.xml
+++ b/tests/testthat/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<checkstyle version="lintr-2.0.1">
+<checkstyle version="lintr-2.0.1.9000">
   <file name="test_file">
     <error line="1" column="2" severity="error" message="foo"/>
     <error line="2" column="1" severity="info" message="bar"/>

--- a/tests/testthat/knitr_formats/test.Rmd
+++ b/tests/testthat/knitr_formats/test.Rmd
@@ -35,6 +35,17 @@ Plain code blocks can be written after three or more backticks
 - R Markdown: The Definitive Guide. Xie, Allaire and Grolemund (2.5.2)
 ```
 
+```r
+# This is a non-evaluated block of R code for formatting in markdown.
+# It should not be linted
+abc = 123
+```
+
+```cpp
+// Some C++ code for formatting by markdown
+
+```
+
 Calls to a non-R knitr-engine using {engine_name} syntax.
 
 ```{python}

--- a/tests/testthat/knitr_malformed/incomplete_r_block.Rmd
+++ b/tests/testthat/knitr_malformed/incomplete_r_block.Rmd
@@ -1,0 +1,14 @@
+# Test #
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+```{r}
+a = 1
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren,
+no sea takimata sanctus est Lorem ipsum dolor sit amet.

--- a/tests/testthat/test-knitr_formats.R
+++ b/tests/testthat/test-knitr_formats.R
@@ -1,5 +1,12 @@
 context("knitr_formats")
 
+regexes <- list(
+  assign = rex("Use <-, not =, for assignment."),
+  local_var = rex("local variable"),
+  quotes = rex("Only use double-quotes."),
+  trailing = rex("Trailing blank lines are superfluous.")
+)
+
 test_that("it handles dir", {
   lints <- lint_dir(path = "knitr_formats", pattern = rex::rex(".R", one_of("html", "md", "nw", "rst", "tex", "txt")))
   has_lints <- length(lints) > 0
@@ -8,69 +15,73 @@ test_that("it handles dir", {
   testthat::expect_equivalent(length(unique(names(lints))), 6, info="For every file there should be at least 1 lint")
 })
 
-
 test_that("it handles markdown", {
   expect_lint(file = "knitr_formats/test.Rmd",
     checks = list(
-      list(rex("Use <-, not =, for assignment."), line_number = 9),
-      list(rex("local variable"), line_number = 22),
-      list(rex("Use <-, not =, for assignment."), line_number = 22),
-      list(rex("Trailing blank lines are superfluous."), line_number = 24)
+      list(regexes[["assign"]], line_number = 9),
+      list(regexes[["local_var"]], line_number = 22),
+      list(regexes[["assign"]], line_number = 22),
+      list(regexes[["trailing"]], line_number = 24)
     ),
     default_linters
   )
 })
+
 test_that("it handles Sweave", {
   expect_lint(file = "knitr_formats/test.Rnw",
     checks = list(
-      list(rex("Use <-, not =, for assignment."), line_number = 12),
-      list(rex("local variable"), line_number = 24),
-      list(rex("Use <-, not =, for assignment."), line_number = 24),
-      list(rex("Trailing blank lines are superfluous."), line_number = 26)
+      list(regexes[["assign"]], line_number = 12),
+      list(regexes[["local_var"]], line_number = 24),
+      list(regexes[["assign"]], line_number = 24),
+      list(regexes[["trailing"]], line_number = 26)
     ),
     default_linters
   )
 })
+
 test_that("it handles reStructuredText", {
   expect_lint(file = "knitr_formats/test.Rrst",
     checks = list(
-      list(rex("Use <-, not =, for assignment."), line_number = 10),
-      list(rex("local variable"), line_number = 23),
-      list(rex("Use <-, not =, for assignment."), line_number = 23),
-      list(rex("Trailing blank lines are superfluous."), line_number = 25)
+      list(regexes[["assign"]], line_number = 10),
+      list(regexes[["local_var"]], line_number = 23),
+      list(regexes[["assign"]], line_number = 23),
+      list(regexes[["trailing"]], line_number = 25)
     ),
     default_linters
   )
 })
+
 test_that("it handles HTML", {
   expect_lint(file = "knitr_formats/test.Rhtml",
     checks = list(
-      list(rex("Use <-, not =, for assignment."), line_number = 15),
-      list(rex("local variable"), line_number = 27),
-      list(rex("Use <-, not =, for assignment."), line_number = 27),
-      list(rex("Trailing blank lines are superfluous."), line_number = 29)
+      list(regexes[["assign"]], line_number = 15),
+      list(regexes[["local_var"]], line_number = 27),
+      list(regexes[["assign"]], line_number = 27),
+      list(regexes[["trailing"]], line_number = 29)
     ),
     default_linters
   )
 })
+
 test_that("it handles tex", {
   expect_lint(file = "knitr_formats/test.Rtex",
     checks = list(
-      list(rex("Use <-, not =, for assignment."), line_number = 11),
-      list(rex("local variable"), line_number = 23),
-      list(rex("Use <-, not =, for assignment."), line_number = 23),
-      list(rex("Trailing blank lines are superfluous."), line_number = 25)
+      list(regexes[["assign"]], line_number = 11),
+      list(regexes[["local_var"]], line_number = 23),
+      list(regexes[["assign"]], line_number = 23),
+      list(regexes[["trailing"]], line_number = 25)
     ),
     default_linters
   )
 })
+
 test_that("it handles asciidoc", {
   expect_lint(file = "knitr_formats/test.Rtxt",
     checks = list(
-      list(rex("Use <-, not =, for assignment."), line_number = 9),
-      list(rex("local variable"), line_number = 22),
-      list(rex("Use <-, not =, for assignment."), line_number = 22),
-      list(rex("Trailing blank lines are superfluous."), line_number = 24)
+      list(regexes[["assign"]], line_number = 9),
+      list(regexes[["local_var"]], line_number = 22),
+      list(regexes[["assign"]], line_number = 22),
+      list(regexes[["trailing"]], line_number = 24)
     ),
     default_linters
   )
@@ -79,14 +90,16 @@ test_that("it handles asciidoc", {
 test_that("it does _not_ handle brew", {
   expect_lint("'<% a %>'\n",
     checks = list(
-      rex("Only use double-quotes."),
-      rex("Trailing blank lines are superfluous.")
+      regexes[["quotes"]],
+      regexes[["trailing"]]
     ),
-    default_linters)
+    default_linters
+  )
 })
 
 test_that("it does _not_ error with inline \\Sexpr", {
   expect_lint("#' text \\Sexpr{1 + 1} more text",
     NULL,
-    default_linters)
+    default_linters
+  )
 })

--- a/tests/testthat/test-knitr_formats.R
+++ b/tests/testthat/test-knitr_formats.R
@@ -103,3 +103,10 @@ test_that("it does _not_ error with inline \\Sexpr", {
     default_linters
   )
 })
+
+test_that("it does error with malformed input", {
+  expect_error(
+    lint("knitr_malformed/incomplete_r_block.Rmd"),
+    regex = "Malformed"
+  )
+})


### PR DESCRIPTION
See #472  lintr was complaining that files were malformed when containing
unevaluated code-blocks of the following form (cpp is a format specifier
for use by markdown).
~~~~
```cpp
blah
```
~~~~

~~~~
"```" matches the end-block pattern for Rmd-code blocks; the change
allows the start pattern for unevaluated blocks to be "```" or
"```some_language"
~~~~

A couple of such blocks were added to the .Rmd used in the knitr-format
test.

`extract_r_source` has been refactored: selection of start / end
positions for each code block is handled by `get_chunk_positions`.

Also
- bumped the lintr version from 2.0.1 to 2.0.1.9000
- refactored some knitr-format tests that had some regex-definition duplication
- added a malformed .Rmd containing an incomplete R code block to the tests
- pushed some man/ entries that got updated during devtools::document()