### PR TITLE
Add SNAKE_CASE style option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * `extract_r_source` handles Rmd containing unevaluated code blocks with named
   format specifiers (#472, @russHyde)
+* New style SNAKE_CASE for `object_name_linter()` (#494, @AshesITR)
 
 # lintr 2.0.1
 

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -277,7 +277,7 @@ style_regexes <- list(
   "CamelCase" = rex(start, maybe("."), upper, zero_or_more(alnum), end),
   "camelCase" = rex(start, maybe("."), lower, zero_or_more(alnum), end),
   "snake_case"     = rex(start, maybe("."), some_of(lower, digit), any_of("_", lower, digit), end),
-  "SNAKE_CASE"     = rex(start, maybe("."), some_of(upper, digit), any_of("_", lower, digit), end),
+  "SNAKE_CASE"     = rex(start, maybe("."), some_of(upper, digit), any_of("_", upper, digit), end),
   "dotted.case"    = rex(start, maybe("."), one_or_more(loweralnum), zero_or_more(dot, one_or_more(loweralnum)), end),
   "lowercase"   = rex(start, maybe("."), one_or_more(loweralnum), end),
   "UPPERCASE"   = rex(start, maybe("."), one_or_more(upperalnum), end)

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -277,6 +277,7 @@ style_regexes <- list(
   "CamelCase" = rex(start, maybe("."), upper, zero_or_more(alnum), end),
   "camelCase" = rex(start, maybe("."), lower, zero_or_more(alnum), end),
   "snake_case"     = rex(start, maybe("."), some_of(lower, digit), any_of("_", lower, digit), end),
+  "SNAKE_CASE"     = rex(start, maybe("."), some_of(upper, digit), any_of("_", lower, digit), end),
   "dotted.case"    = rex(start, maybe("."), one_or_more(loweralnum), zero_or_more(dot, one_or_more(loweralnum)), end),
   "lowercase"   = rex(start, maybe("."), one_or_more(loweralnum), end),
   "UPPERCASE"   = rex(start, maybe("."), one_or_more(upperalnum), end)

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ If you need a bit automatic help for re-styling your code, have a look at [the `
 * `no_tab_linter`: check that only spaces are used, never tabs.
 * `object_length_linter`: check that function and variable names are not more than `length` characters.
 * `object_name_linter`: check that object names conform to a single naming
-  style, e.g. CamelCase, camelCase, snake_case, dotted.case, lowercase,
-  or UPPERCASE.
+  style, e.g. CamelCase, camelCase, snake_case, SNAKE_CASE, dotted.case,
+  lowercase, or UPPERCASE.
 * `open_curly_linter`: check that opening curly braces are never on their own
   line and are always followed by a newline.
 * `paren_brace_linter`: check that there is a space between right parenthesis and an opening curly brace.

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -3,42 +3,44 @@ context("object_name_linter")
 
 test_that("styles are correctly identified", {
   styles <- names(style_regexes)
-  #                                                                UpC   lowC     snake    dot  alllow  ALLUP
-  expect_equivalent(lapply(styles, check_style, nms = "x"), list(FALSE,  TRUE,  TRUE,  TRUE,   TRUE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = ".x"), list(FALSE,  TRUE,  TRUE,  TRUE,   TRUE, FALSE))
-  #expect_equivalent(lapply(styles, check_style, nms = "..x"), list(FALSE,  TRUE,  TRUE,  TRUE,   TRUE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "X"), list( TRUE, FALSE, FALSE, FALSE,  FALSE,  TRUE))
-  expect_equivalent(lapply(styles, check_style, nms = "x."), list(FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "X."), list(FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "x_"), list(FALSE, FALSE, TRUE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "X_"), list(FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "xy"), list(FALSE,  TRUE,  TRUE,  TRUE,   TRUE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "xY"), list(FALSE,  TRUE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "Xy"), list( TRUE, FALSE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "XY"), list( TRUE, FALSE, FALSE, FALSE,  FALSE,  TRUE))
-  expect_equivalent(lapply(styles, check_style, nms = "x1"), list(FALSE,  TRUE,  TRUE,  TRUE,   TRUE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "X1"), list( TRUE, FALSE, FALSE, FALSE,  FALSE,  TRUE))
-  expect_equivalent(lapply(styles, check_style, nms = "x_y"), list(FALSE, FALSE,  TRUE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "X.Y"), list(FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "x_2"), list(FALSE, FALSE,  TRUE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "X_2"), list(FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "x.2"), list(FALSE, FALSE, FALSE,  TRUE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "X.2"), list(FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  #                                                                UpC   lowC   snake  SNAKE  dot    alllow  ALLUP
+  expect_equivalent(lapply(styles, check_style, nms = "x"  ), list(FALSE,  TRUE,  TRUE, FALSE,  TRUE,   TRUE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = ".x" ), list(FALSE,  TRUE,  TRUE, FALSE,  TRUE,   TRUE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X"  ), list( TRUE, FALSE, FALSE,  TRUE, FALSE,  FALSE,  TRUE))
+  expect_equivalent(lapply(styles, check_style, nms = "x." ), list(FALSE, FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X." ), list(FALSE, FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "x_" ), list(FALSE, FALSE,  TRUE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X_" ), list(FALSE, FALSE, FALSE,  TRUE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "xy" ), list(FALSE,  TRUE,  TRUE, FALSE,  TRUE,   TRUE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "xY" ), list(FALSE,  TRUE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "Xy" ), list( TRUE, FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "XY" ), list( TRUE, FALSE, FALSE,  TRUE, FALSE,  FALSE,  TRUE))
+  expect_equivalent(lapply(styles, check_style, nms = "x1" ), list(FALSE,  TRUE,  TRUE, FALSE,  TRUE,   TRUE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X1" ), list( TRUE, FALSE, FALSE,  TRUE, FALSE,  FALSE,  TRUE))
+  expect_equivalent(lapply(styles, check_style, nms = "x_y"), list(FALSE, FALSE,  TRUE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X_Y"), list(FALSE, FALSE,  TRUE,  TRUE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X.Y"), list(FALSE, FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "x_2"), list(FALSE, FALSE,  TRUE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X_2"), list(FALSE, FALSE, FALSE,  TRUE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "x.2"), list(FALSE, FALSE, FALSE, FALSE,  TRUE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X.2"), list(FALSE, FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
 
 
-  #                                                      UpC   lowC  snake    dot  alllow  ALLUP
-  expect_equivalent(lapply(styles, check_style, nms = "IHave1Cat"    ), c( TRUE, FALSE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "iHave1Cat"    ), c(FALSE,  TRUE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "i_have_1_cat" ), c(FALSE, FALSE,  TRUE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "i.have.1.cat" ), c(FALSE, FALSE, FALSE,  TRUE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "ihave1cat"    ), c(FALSE,  TRUE,  TRUE,  TRUE,   TRUE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "IHAVE1CAT"    ), c( TRUE, FALSE, FALSE, FALSE,  FALSE,  TRUE))
-  expect_equivalent(lapply(styles, check_style, nms = "I.HAVE_ONECAT"), c(FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  #                                                                       UpC   lowC   snake  SNAKE  dot    alllow  ALLUP
+  expect_equivalent(lapply(styles, check_style, nms = "IHave1Cat"    ), c( TRUE, FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "iHave1Cat"    ), c(FALSE,  TRUE, FALSE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "i_have_1_cat" ), c(FALSE, FALSE,  TRUE, FALSE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "I_HAVE_1_CAT" ), c(FALSE, FALSE, FALSE,  TRUE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "i.have.1.cat" ), c(FALSE, FALSE, FALSE, FALSE,  TRUE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "ihave1cat"    ), c(FALSE,  TRUE,  TRUE, FALSE,  TRUE,   TRUE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "IHAVE1CAT"    ), c( TRUE, FALSE, FALSE,  TRUE, FALSE,  FALSE,  TRUE))
+  expect_equivalent(lapply(styles, check_style, nms = "I.HAVE_ONECAT"), c(FALSE, FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
 })
 
 test_that("linter ignores some objects", {
   # names for which style check is ignored
   expect_lint("`%x%` <- t", NULL, object_name_linter("snake_case"))              # operator
+  expect_lint("`%x%` <- t", NULL, object_name_linter("SNAKE_CASE"))              # operator
   expect_lint("`t.test` <- t", NULL, object_name_linter("UPPERCASE"))         # std pkg
   expect_lint(".Deprecated('x')", NULL, object_name_linter("lowercase"))      # std pkg
   expect_lint("print.foo <- t", NULL, object_name_linter("CamelCase"))         # S3 generic

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -18,7 +18,7 @@ test_that("styles are correctly identified", {
   expect_equivalent(lapply(styles, check_style, nms = "x1" ), list(FALSE,  TRUE,  TRUE, FALSE,  TRUE,   TRUE, FALSE))
   expect_equivalent(lapply(styles, check_style, nms = "X1" ), list( TRUE, FALSE, FALSE,  TRUE, FALSE,  FALSE,  TRUE))
   expect_equivalent(lapply(styles, check_style, nms = "x_y"), list(FALSE, FALSE,  TRUE, FALSE, FALSE,  FALSE, FALSE))
-  expect_equivalent(lapply(styles, check_style, nms = "X_Y"), list(FALSE, FALSE,  TRUE,  TRUE, FALSE,  FALSE, FALSE))
+  expect_equivalent(lapply(styles, check_style, nms = "X_Y"), list(FALSE, FALSE, FALSE,  TRUE, FALSE,  FALSE, FALSE))
   expect_equivalent(lapply(styles, check_style, nms = "X.Y"), list(FALSE, FALSE, FALSE, FALSE, FALSE,  FALSE, FALSE))
   expect_equivalent(lapply(styles, check_style, nms = "x_2"), list(FALSE, FALSE,  TRUE, FALSE, FALSE,  FALSE, FALSE))
   expect_equivalent(lapply(styles, check_style, nms = "X_2"), list(FALSE, FALSE, FALSE,  TRUE, FALSE,  FALSE, FALSE))
@@ -40,7 +40,7 @@ test_that("styles are correctly identified", {
 test_that("linter ignores some objects", {
   # names for which style check is ignored
   expect_lint("`%x%` <- t", NULL, object_name_linter("snake_case"))              # operator
-  expect_lint("`%x%` <- t", NULL, object_name_linter("SNAKE_CASE"))              # operator
+  expect_lint("`%X%` <- t", NULL, object_name_linter("SNAKE_CASE"))              # operator
   expect_lint("`t.test` <- t", NULL, object_name_linter("UPPERCASE"))         # std pkg
   expect_lint(".Deprecated('x')", NULL, object_name_linter("lowercase"))      # std pkg
   expect_lint("print.foo <- t", NULL, object_name_linter("CamelCase"))         # S3 generic


### PR DESCRIPTION
I like to write variables in snake_case except when they are CONSTANTS.
To prevent the `object_name_linter` from complaining, I would like to allow (uppercase) "SNAKE_CASE" as an option.