### PR TITLE
recursively create cache directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # lintr (development version)
 
+* `save_cache` will now recursively create the cache directory; this avoids errors that could arise if any parent directories do not exist (#60, @dankessler).
 * `extract_r_source` handles Rmd containing unevaluated code blocks with named
   format specifiers (#472, @russHyde)
 * New style SNAKE_CASE for `object_name_linter()` (#494, @AshesITR)

--- a/R/cache.R
+++ b/R/cache.R
@@ -51,7 +51,7 @@ save_cache <- function(cache, file, path = NULL) {
   }
 
   if (!file.exists(path)) {
-    dir.create(path)
+    dir.create(path, recursive = TRUE)
   }
 
   save(file = get_cache_file_path(file, path), envir = cache, list = ls(envir = cache))


### PR DESCRIPTION
This should fix #60. As discussed in the links from that issue, by
default ESS turns on caching, which causes lintr to try to create a
subdirectory inside of ~/.R. However, if ~/.R doesn't exist in the
first place, dir.create will fail and lintr will not work in emacs. By
adding the recursive = TRUE argument to dir.create, this will now
create all parent directories as necessary to create the desired cache.

After this (very tiny) fix, the `testthat` suite succeeds (provided `mockery` is available. 

To test whether this addresses the issue in emacs, I've used vagrant to create a clean Ubuntu 20.04 VM, installed emacs and r, installed some lintr dependencies with apt, then used devtools to install from my github fork. I then configured ESS and confirmed that linting now works! I previously took essentially the same approach when [initially trying to verify the problem](https://github.com/emacs-ess/ESS/issues/1016): if you use `lintr` from CRAN, it falls down (until you manually create the `~/.R` directory).

<details><summary>Here are the steps to reproduce my testing, if they are of interest</summary>
<pre>
1. vagrant init ubuntu/focal64
2. vagrant up
3. vagrant ssh
4. sudo apt update
5. sudo apt install emacs r-base
6. install lintr dependencies (needed for R package installation)
   1. sudo apt install libxml2-dev libcurl4-openssl-dev libssl-dev
7. launch R: install.packages('devtools')
8. install lintr: devtools::install_github('dankessler/lintr@cache-create-subdir', 'cache-create-subdir')
9. install ESS
   1. download 18.10.2.tgz [[https://ess.r-project.org/downloads/ess/ess-18.10.2.tgz][tgz link]]
   2. unpack
10. launch emacs
    1. elisp in scratch:  (add-to-list 'load-path "~/ess-18.10.2/lisp")
    2. (require 'ess-site)
    3. verify with ess-version
11. create an R file and make a syntax mistake
12. it gets flagged! :)
</pre>
</details>

