### PR TITLE
print RStudio source markers for empty lints

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * `extract_r_source` handles Rmd containing unevaluated code blocks with named
   format specifiers (#472, @russHyde)
 * New style SNAKE_CASE for `object_name_linter()` (#494, @AshesITR)
+* RStudio source markers are cleared when there are no lints (#520, @AshesITR)
 
 # lintr 2.0.1
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -62,10 +62,11 @@ print.lints <- function(x, ...) {
 
         info <- ci_build_info()
 
-        lint_output <-
-          trim_output(paste0(collapse = "\n",
-                             capture.output(invisible(lapply(x, markdown, info, ...)))
-                             )
+        lint_output <- trim_output(
+          paste0(
+            collapse = "\n",
+            capture.output(invisible(lapply(x, markdown, info, ...)))
+          )
         )
 
         github_comment(lint_output, info, ...)
@@ -76,6 +77,10 @@ print.lints <- function(x, ...) {
     if (isTRUE(settings$error_on_lint)) {
       quit("no", 31, FALSE)
     }
+  } else if (getOption("lintr.rstudio_source_markers", TRUE) &&
+             rstudioapi::hasFun("sourceMarkers")) {
+    # Empty lints: clear RStudio source markers
+    rstudio_source_markers(x)
   }
   invisible(x)
 }


### PR DESCRIPTION
Fixes #520