### PR TITLE
WIP: seq_linter detects 1:(length(x) - 1) as well

### DIFF
--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -8,51 +8,56 @@ seq_linter <- function(source_file) {
 
   if (!length(source_file$parsed_content)) return(list())
 
-  xml <- source_file$xml_parsed_content
+  content <- source_file$parsed_content
+  seq_idx <- which(content$token == "':'")
+  n_seq <- length(seq_idx)
+  if (n_seq == 0L) return(list())
 
+  # (probably) overallocate for now
+  out <- vector('list', n_seq)
   bad_funcs <- c("length", "nrow", "ncol", "NROW", "NCOL", "dim")
-  text_clause <- paste0("text() = '", bad_funcs, "'", collapse = " or ")
+  out_i <- 1L
+  for (seq_i in seq_idx) {
+    seq_parent <- content$parent[seq_i]
+    sibling_ids <- content$id[content$parent == seq_parent]
 
-  xpath <- paste0(
-    "//expr",
-    "[expr[NUM_CONST[text()='1' or text()='1L']]]",
-    "[OP-COLON]",
-    "[expr[expr[(expr|self::*)[SYMBOL_FUNCTION_CALL[", text_clause, "]]]]]"
-  )
+    # assumes content is in line-col order
+    seq_lhs_id <- sibling_ids[1L]
+    seq_lhs_children <- which(content$parent == seq_lhs_id)
+    if (length(seq_lhs_children) != 1L || content$text[seq_lhs_children] != "1")
+      next
 
-  badx <- xml2::xml_find_all(xml, xpath)
+    seq_rhs_id <- sibling_ids[length(sibling_ids)]
+    seq_rhs_children <- content[content$parent == seq_rhs_id, ]
+    if (!any(seq_rhs_children$text == "(")) next
+    if (seq_rhs_children$token[1L] != "expr") next
+    rhs_first_expr_children <- which(content$parent == seq_rhs_children$id[1L])
+    if (length(rhs_first_expr_children) != 1L ||
+          content$token[rhs_first_expr_children] != "SYMBOL_FUNCTION_CALL" ||
+          ! content$text[rhs_first_expr_children] %in% bad_funcs)
+      next
+    rhs_expr <- content[content$id == seq_rhs_id, ]
+    rhs_text <- with(rhs_expr, substr(source_file$lines[[line1]], col1, col2))
 
-  ## The actual order of the nodes is document order
-  ## In practice we need to handle length(x):1
-  get_fun <- function(x, n) {
-    funcall <- xml2::xml_children(xml2::xml_children(x)[[n]])
-    if (!length(funcall)) return(NULL)
-    fun <- gsub("\\(.*\\)", "(...)", trim_ws(xml2::xml_text(funcall[[1]])))
-    if (! fun %in% bad_funcs) fun else paste0(fun, "(...)")
+    line1 = content$line1[seq_lhs_children]
+    col1 = content$col1[seq_lhs_children]
+    out[[out_i]] = Lint(
+      filename = source_file$filename,
+      line_number = line1,
+      column_number = col1,
+      type = "warning",
+      message = paste0(
+        "Avoid " , content$text[seq_lhs_children], ":", rhs_text,
+        " expressions, use seq_len"
+      ),
+      line = source_file$lines[[line1]],
+      ranges = list(c(col1, content$col2[seq_lhs_children])),
+      linter = "seq_linter"
+    )
+
+    out_i <- out_i + 1L
   }
-
-  ## Unfortunately the more natural lapply(badx, ...) does not work,
-  ## because badx looses its class for length() and/or [[
-  lapply(
-    seq_along(badx),
-    function(i) {
-      x <- badx[[i]]
-      f1 <- get_fun(x, 1)
-      f2 <- get_fun(x, 3)
-      line1 <- xml2::xml_attr(x, "line1")
-      col1 <- xml2::xml_attr(x, "col1")
-      col2 <- xml2::xml_attr(x, "col1")
-      Lint(
-        filename = source_file$filename,
-        line_number = as.integer(line1),
-        column_number = as.integer(col1),
-        type = "warning",
-        message = paste0("Avoid ", f1, ":", f2,
-          " expressions, use seq_len."),
-        line = source_file$lines[line1],
-        ranges = list(c(as.integer(col1), as.integer(col2))),
-        linter = "seq_linter"
-      )
-    }
-  )
+  # trim the overallocated parts
+  if (out_i <= n_seq) out[out_i:n_seq] = NULL
+  out
 }


### PR DESCRIPTION
Closes #525 

Currently migrating to use parsed_content instead of the XML approach (may or may not be advisable).

Next will be to extend the logic for the `1:(length(x)-1)` case