### PR TITLE
get_source_expressions detects terminal newlines

### DIFF
--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -2,10 +2,47 @@
 #'
 #' This object is given as input to each linter
 #' @param filename the file to be parsed.
+#' @return A `list` with three components: (1) `expressions`, a `list` of
+#'   `n+1` objects. The first `n` elements correspond to each expressions in
+#'   `filename`, and consist of a list of 9 elements:
+#'   (1) `filename` (`character`); (2) `line` (`integer`) the line in `filename`
+#'   where this expression begins; (3) `column` (`integer`) the column in
+#'   `filename` where this expression begins; (4) `lines` (named `character`)
+#'   vector of all lines spanned by this expression, named with the line number
+#'   corresponding to `filename`; (5) `parsed_content` (`data.frame`) as given
+#'   by [utils::getParseData()] for this expression; (6) `xml_parsed_content`
+#'   (`xml_document`) the XML parse tree of this expression as given by
+#'   [xmlparsedata::xml_parse_data()]; (7) `content` (`character`) the same as
+#'   `lines` as a single string (not split across lines); (8) `find_line`
+#'   (`function`) a function for returning lines in this expression; and (9)
+#'   `find_column` (`function`) a similar function for columns. The final
+#'   element of `expressions` is a list corresponding to the full file
+#'   consisting of 6 elements: (1) `filename` (`character`); (2) `file_lines`
+#'   (`character`) the [readLines()] output for this file; (3) `content`
+#'   (`character`) for .R files, the same as `file_lines`; for .Rmd scripts,
+#'   this is the extracted R source code (as text); (4) `full_parsed_content`
+#'   (`data.frame`) as given by [utils::getParseData()] for the full content;
+#'   (5) `xml_parsed_content` (`xml_document`) the XML parse tree of all
+#'   expressions as given by [xmlparsedata::xml_parse_data()]; and (6)
+#'   `terminal_newline` (`logical`) records whether `filename` has a terminal
+#'   newline (as determined by [readLines()] producing a corresponding warning).
+#'   (2) `error` a `Lint` object describing any parsing error. (3) `lines` the
+#'   [readLines()] output for this file.
 #' @export
 get_source_expressions <- function(filename) {
   source_file <- srcfile(filename)
-  source_file$lines <- readLines(filename)
+  terminal_newline <- FALSE
+  source_file$lines <- withCallingHandlers(
+    {
+      readLines(filename)
+    },
+    warning = function(w) {
+      if (grepl("incomplete final line found on", w$message, fixed = TRUE)) {
+        terminal_newline <<- TRUE
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
   source_file$lines <- extract_r_source(source_file$filename, source_file$lines)
   source_file$content <- get_content(source_file$lines)
 
@@ -94,7 +131,8 @@ get_source_expressions <- function(filename) {
       file_lines = source_file$lines,
       content = source_file$lines,
       full_parsed_content = parsed_content,
-      xml_parsed_content = if (!is.null(parsed_content)) tryCatch(xml2::read_xml(xmlparsedata::xml_parse_data(parsed_content)), error = function(e) NULL)
+      xml_parsed_content = if (!is.null(parsed_content)) tryCatch(xml2::read_xml(xmlparsedata::xml_parse_data(parsed_content)), error = function(e) NULL),
+      terminal_newline = terminal_newline
     )
 
   list(expressions = expressions, error = e, lines = source_file$lines)

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -2,33 +2,43 @@
 #'
 #' This object is given as input to each linter
 #' @param filename the file to be parsed.
-#' @return A `list` with three components: (1) `expressions`, a `list` of
-#'   `n+1` objects. The first `n` elements correspond to each expressions in
+#' @return A `list` with three components:
+#'   \item{expressions}{a `list` of
+#'   `n+1` objects. The first `n` elements correspond to each expression in
 #'   `filename`, and consist of a list of 9 elements:
-#'   (1) `filename` (`character`); (2) `line` (`integer`) the line in `filename`
-#'   where this expression begins; (3) `column` (`integer`) the column in
-#'   `filename` where this expression begins; (4) `lines` (named `character`)
-#'   vector of all lines spanned by this expression, named with the line number
-#'   corresponding to `filename`; (5) `parsed_content` (`data.frame`) as given
-#'   by [utils::getParseData()] for this expression; (6) `xml_parsed_content`
-#'   (`xml_document`) the XML parse tree of this expression as given by
-#'   [xmlparsedata::xml_parse_data()]; (7) `content` (`character`) the same as
-#'   `lines` as a single string (not split across lines); (8) `find_line`
-#'   (`function`) a function for returning lines in this expression; and (9)
-#'   `find_column` (`function`) a similar function for columns. The final
-#'   element of `expressions` is a list corresponding to the full file
-#'   consisting of 6 elements: (1) `filename` (`character`); (2) `file_lines`
-#'   (`character`) the [readLines()] output for this file; (3) `content`
-#'   (`character`) for .R files, the same as `file_lines`; for .Rmd scripts,
-#'   this is the extracted R source code (as text); (4) `full_parsed_content`
-#'   (`data.frame`) as given by [utils::getParseData()] for the full content;
-#'   (5) `xml_parsed_content` (`xml_document`) the XML parse tree of all
-#'   expressions as given by [xmlparsedata::xml_parse_data()]; and (6)
-#'   `terminal_newline` (`logical`) records whether `filename` has a terminal
-#'   newline (as determined by [readLines()] producing a corresponding warning).
-#'   (2) `error` a `Lint` object describing any parsing error. (3) `lines` the
-#'   [readLines()] output for this file.
+#'   \itemize{
+#'     \item{`filename` (`character`)}
+#'     \item{`line` (`integer`) the line in `filename` where this expression begins}
+#'     \item{`column` (`integer`) the column in `filename` where this expression begins}
+#'     \item{`lines` (named `character`) vector of all lines spanned by this
+#'           expression, named with the line number corresponding to `filename`}
+#'     \item{`parsed_content` (`data.frame`) as given by [utils::getParseData()] for this expression}
+#'     \item{`xml_parsed_content` (`xml_document`) the XML parse tree of this
+#'          expression as given by [xmlparsedata::xml_parse_data()]}
+#'     \item{`content` (`character`) the same as `lines` as a single string (not split across lines)}
+#'     \item{`find_line` (`function`) a function for returning lines in this expression}
+#'     \item{`find_column` (`function`) a similar function for columns}
+#'   }
+#'
+#'   The final element of `expressions` is a list corresponding to the full file
+#'   consisting of 6 elements:
+#'   \itemize{
+#'     \item{`filename` (`character`)}
+#'     \item{`file_lines` (`character`) the [readLines()] output for this file}
+#'     \item{`content` (`character`) for .R files, the same as `file_lines`;
+#'           for .Rmd scripts, this is the extracted R source code (as text)}
+#'     \item{`full_parsed_content` (`data.frame`) as given by
+#'           [utils::getParseData()] for the full content}
+#'     \item{`xml_parsed_content` (`xml_document`) the XML parse tree of all
+#'           expressions as given by [xmlparsedata::xml_parse_data()]}
+#'     \item{`terminal_newline` (`logical`) records whether `filename` has a terminal
+#'           newline (as determined by [readLines()] producing a corresponding warning)}
+#'   }
+#'   }
+#'   \item{error}{A `Lint` object describing any parsing error.}
+#'   \item{lines}{The [readLines()] output for this file.}
 #' @export
+#' @md
 get_source_expressions <- function(filename) {
   source_file <- srcfile(filename)
   terminal_newline <- FALSE

--- a/man/get_source_expressions.Rd
+++ b/man/get_source_expressions.Rd
@@ -9,6 +9,43 @@ get_source_expressions(filename)
 \arguments{
 \item{filename}{the file to be parsed.}
 }
+\value{
+A \code{list} with three components:
+\item{expressions}{a \code{list} of
+\code{n+1} objects. The first \code{n} elements correspond to each expressions in
+\code{filename}, and consist of a list of 9 elements:
+\itemize{
+\item{\code{filename} (\code{character})}
+\item{\code{line} (\code{integer}) the line in \code{filename} where this expression begins}
+\item{\code{column} (\code{integer}) the column in \code{filename} where this expression begins}
+\item{\code{lines} (named \code{character}) vector of all lines spanned by this
+expression, named with the line number corresponding to \code{filename}}
+\item{\code{parsed_content} (\code{data.frame}) as given by \code{\link[utils:getParseData]{utils::getParseData()}} for this expression}
+\item{\code{xml_parsed_content} (\code{xml_document}) the XML parse tree of this
+expression as given by \code{\link[xmlparsedata:xml_parse_data]{xmlparsedata::xml_parse_data()}}}
+\item{\code{content} (\code{character}) the same as \code{lines} as a single string (not split across lines)}
+\item{\code{find_line} (\code{function}) a function for returning lines in this expression}
+\item{\code{find_column} (\code{function}) a similar function for columns}
+}
+
+The final element of \code{expressions} is a list corresponding to the full file
+consisting of 6 elements:
+\itemize{
+\item{\code{filename} (\code{character})}
+\item{\code{file_lines} (\code{character}) the \code{\link[=readLines]{readLines()}} output for this file}
+\item{\code{content} (\code{character}) for .R files, the same as \code{file_lines};
+for .Rmd scripts, this is the extracted R source code (as text)}
+\item{\code{full_parsed_content} (\code{data.frame}) as given by
+\code{\link[utils:getParseData]{utils::getParseData()}} for the full content}
+\item{\code{xml_parsed_content} (\code{xml_document}) the XML parse tree of all
+expressions as given by \code{\link[xmlparsedata:xml_parse_data]{xmlparsedata::xml_parse_data()}}}
+\item{\code{terminal_newline} (\code{logical}) records whether \code{filename} has a terminal
+newline (as determined by \code{\link[=readLines]{readLines()}} producing a corresponding warning)}
+}
+}
+\item{error}{A \code{Lint} object describing any parsing error.}
+\item{lines}{The \code{\link[=readLines]{readLines()}} output for this file.}
+}
 \description{
 This object is given as input to each linter
 }

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -60,3 +60,18 @@ test_that("tab positions have been corrected", {
     )
   })
 })
+
+test_that("Terminal newlines are detected correctly", {
+  writeLines("lm(y ~ x)", tmp <- tempfile())
+  writeBin(
+    # strip the last element (\n)
+    head(readBin(tmp, raw(), file.size(tmp)), -1L),
+    tmp2 <- tempfile()
+  )
+
+  expect_true(get_source_expressions(tmp)$expressions[[2L]]$terminal_newline)
+  expect_false(get_source_expressions(tmp2)$expressions[[2L]]$terminal_newline)
+
+  unlink(tmp)
+  unlink(tmp2)
+})

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -63,15 +63,14 @@ test_that("tab positions have been corrected", {
 
 test_that("Terminal newlines are detected correctly", {
   writeLines("lm(y ~ x)", tmp <- tempfile())
+  on.exit(unlink(tmp), add=TRUE)
   writeBin(
     # strip the last element (\n)
     head(readBin(tmp, raw(), file.size(tmp)), -1L),
     tmp2 <- tempfile()
   )
+  on.exit(unlink(tmp2), add=TRUE)
 
   expect_true(get_source_expressions(tmp)$expressions[[2L]]$terminal_newline)
   expect_false(get_source_expressions(tmp2)$expressions[[2L]]$terminal_newline)
-
-  unlink(tmp)
-  unlink(tmp2)
 })


### PR DESCRIPTION
Closes #542 

Comment wanted:

 1. I documented `get_source_expressions` return object pretty thoroughly. Should this be filed as a separate PR perhaps? Also please have a look to be sure it makes sense, I wasn't totally clear on what all of the components are. If it's good to include in this PR I'll `document()` it.
 2. I didn't include the linter in this PR, the thinking is to file a separate issue & PR as a follow-up. Happy to write it here as well.
 3. I didn't touch the `readLine` usages in R/exclude.R and R/cache.R. I can look into that as needed.