### PR TITLE
Fix handling zero-length variable name error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * New `missing_package_linter()` (#536, #547, @renkun-ken)
 * New `namespace_linter()` (#548, #551, @renkun-ken)
 * Fix possible error on invalid XML produced by xmlparsedata (#559, #560, @renkun-ken)
+* Fix handling zero-length variable name error (#566, #567, @renkun-ken)
 
 # lintr 2.0.1
 

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -71,7 +71,6 @@ get_source_expressions <- function(filename) {
           anything),
         "\n")
       )
-      
 
     # an error that does not use R_ParseErrorMsg
     if (is.na(message_info$line)) {

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -85,7 +85,7 @@ get_source_expressions <- function(filename) {
       line_location <- line_location[complete.cases(line_location), ]
 
       if (nrow(line_location) == 0L) {
-        if (grepl("attempt to use zero-length variable name", e$message)) {
+        if (grepl("attempt to use zero-length variable name", e$message, fixed = TRUE)) {
           # empty symbol: ``, ``(), ''(), ""(), fun(''=42), fun(""=42), fun(a=1,""=42)
           loc <- re_matches(source_file$content,
             rex("``" %or% list(or("''", '""'), any_spaces, "(") %or%

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -86,7 +86,7 @@ get_source_expressions <- function(filename) {
 
       if (nrow(line_location) == 0L) {
         if (grepl("attempt to use zero-length variable name", e$message)) {
-          # empty symbol: ``, ``(), ''(), ""(), fun(''=42), fun(""=42)
+          # empty symbol: ``, ``(), ''(), ""(), fun(''=42), fun(""=42), fun(a=1,""=42)
           loc <- re_matches(source_file$content,
             rex("``" %or% list(or("''", '""'), any_spaces, "(") %or%
               list(or("(", ","), any_spaces, or("''", '""'), any_spaces, "=")),

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -88,7 +88,10 @@ get_source_expressions <- function(filename) {
         if (grepl("attempt to use zero-length variable name", e$message)) {
           # empty symbol: ``, ``(), ''(), ""(), fun(''=42), fun(""=42)
           loc <- re_matches(source_file$content,
-            "``|''\\s*\\(|\"\"\\s*\\(|\\(''\\s*=|\\(\"\"\\s*=", locations = TRUE)
+            rex("``" %or% list(or("''", '""'), any_spaces, "(") %or%
+              list(or("(", ","), any_spaces, or("''", '""'), any_spaces, "=")),
+            options = "multi-line",
+            locations = TRUE)
           loc <- loc[complete.cases(loc), ]
           if (nrow(loc) > 0) {
             line_location <- loc[1, ]

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -55,7 +55,7 @@ test_that("returns the correct linting", {
     rex("attempt to use zero-length variable name")
   )
 
-  expect_lint("\"\"()",
+  expect_lint('""()',
     rex("attempt to use zero-length variable name")
   )
 
@@ -63,11 +63,11 @@ test_that("returns the correct linting", {
     rex("attempt to use zero-length variable name")
   )
 
-  expect_lint("fun(\"\"=42)",
+  expect_lint('fun(""=42)',
     rex("attempt to use zero-length variable name")
   )
 
-  expect_lint("fun(a=1,\"\"=42)",
+  expect_lint('fun(a=1,""=42)',
     rex("attempt to use zero-length variable name")
   )
 })

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -42,4 +42,32 @@ test_that("returns the correct linting", {
   expect_lint("\\",
     rex("unexpected input")
   )
+
+  expect_lint("``",
+    rex("attempt to use zero-length variable name")
+  )
+
+  expect_lint("``()",
+    rex("attempt to use zero-length variable name")
+  )
+
+  expect_lint("''()",
+    rex("attempt to use zero-length variable name")
+  )
+
+  expect_lint("\"\"()",
+    rex("attempt to use zero-length variable name")
+  )
+
+  expect_lint("fun(''=42)",
+    rex("attempt to use zero-length variable name")
+  )
+
+  expect_lint("fun(\"\"=42)",
+    rex("attempt to use zero-length variable name")
+  )
+
+  expect_lint("fun(a=1,\"\"=42)",
+    rex("attempt to use zero-length variable name")
+  )
 })


### PR DESCRIPTION
Closes #566.

This PR checks if the parse error message has a hint for the source code error and fixes the handling of `attempt to use zero-length variable name` error caused by empty variable names in the following cases:

```r
``
``()
''()
""()
fun(''=42)
fun(""=42)
fun(a=1,""=42)
```

When this error occurs, it searches the source code with a pattern that covers the above cases.

* [x] Fix handling of error
* [x] Test case