### PR TITLE
Only checks with full parse data

### DIFF
--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -4,7 +4,7 @@
 missing_argument_linter <- function(except = c("switch", "alist")) {
   function(source_file) {
 
-    if (!length(source_file$parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
+    if (!length(source_file$full_parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
 
     xml <- source_file$xml_parsed_content
 
@@ -31,7 +31,7 @@ missing_argument_linter <- function(except = c("switch", "alist")) {
           column_number = col1[[i]],
           type = "warning",
           message = "Missing argument in function call.",
-          line = source_file$lines[line1[[i]]],
+          line = source_file$file_lines[line1[[i]]],
           ranges = list(c(col1[[i]], col2[[i]])),
           linter = "missing_argument_linter"
         )

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -3,7 +3,7 @@
 #' @export
 missing_package_linter <- function(source_file) {
 
-  if (!length(source_file$parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
+  if (!length(source_file$full_parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
 
   xml <- source_file$xml_parsed_content
 
@@ -36,7 +36,7 @@ missing_package_linter <- function(source_file) {
       column_number = col1[[i]],
       type = "warning",
       message = sprintf("Package '%s' is not installed.", pkg_names[[i]]),
-      line = source_file$lines[line1[[i]]],
+      line = source_file$file_lines[line1[[i]]],
       ranges = list(c(col1[[i]], col2[[i]])),
       linter = "missing_package_linter"
     )

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -8,7 +8,7 @@
 #' @export
 namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
   function(source_file) {
-    if (!length(source_file$parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
+    if (!length(source_file$full_parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
 
     xml <- source_file$xml_parsed_content
 
@@ -47,7 +47,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
                   column_number = col1,
                   type = "warning",
                   message = sprintf("'%s' is not exported from {%s}.", syms[[i]], pkgs[[i]]),
-                  line = source_file$lines[line1],
+                  line = source_file$file_lines[line1],
                   ranges = list(c(col1, col2)),
                   linter = "namespace_linter"
                 ))
@@ -68,7 +68,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
                     type = "style",
                     message = sprintf("'%s' is exported from {%s}. Use %s::%s instead.",
                       syms[[i]], pkgs[[i]], pkgs[[i]], syms[[i]]),
-                    line = source_file$lines[line1],
+                    line = source_file$file_lines[line1],
                     ranges = list(c(col1, col2)),
                     linter = "namespace_linter"
                   ))
@@ -83,7 +83,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
                   column_number = col1,
                   type = "warning",
                   message = sprintf("'%s' does not exist in {%s}.", syms[[i]], pkgs[[i]]),
-                  line = source_file$lines[line1],
+                  line = source_file$file_lines[line1],
                   ranges = list(c(col1, col2)),
                   linter = "namespace_linter"
                 ))
@@ -99,7 +99,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
               column_number = col1,
               type = "warning",
               message = conditionMessage(ns),
-              line = source_file$lines[line1],
+              line = source_file$file_lines[line1],
               ranges = list(c(col1, col2)),
               linter = "namespace_linter"
             ))
@@ -115,7 +115,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
           column_number = col1,
           type = "warning",
           message = sprintf("Package '%s' is not installed.", pkgs[[i]]),
-          line = source_file$lines[line1],
+          line = source_file$file_lines[line1],
           ranges = list(c(col1, col2)),
           linter = "namespace_linter"
         ))

--- a/tests/testthat/test-missing_argument_linter.R
+++ b/tests/testthat/test-missing_argument_linter.R
@@ -36,6 +36,10 @@ test_that("returns the correct linting", {
     list(message = rex("Missing argument in function call.")),
     missing_argument_linter())
 
+  expect_lint("f <- function(x, y) x\nf(, y = 1)\n",
+    list(line = "f(, y = 1)"),
+    missing_argument_linter())
+
   expect_lint("fun(a = 1,, b = 2)",
     list(message = rex("Missing argument in function call.")),
     missing_argument_linter())

--- a/tests/testthat/test-missing_package_linter.R
+++ b/tests/testthat/test-missing_package_linter.R
@@ -28,6 +28,10 @@ test_that("returns the correct linting", {
     list(message = rex("Package 'statts' is not installed.")),
     missing_package_linter)
 
+  expect_lint("library(utils)\nlibrary(statts)\n",
+    list(line = "library(statts)"),
+    missing_package_linter)
+
   expect_lint("library(statts, quietly = TRUE)",
     list(message = rex("Package 'statts' is not installed.")),
     missing_package_linter)

--- a/tests/testthat/test-namespace_linter.R
+++ b/tests/testthat/test-namespace_linter.R
@@ -55,4 +55,8 @@ test_that("returns the correct linting", {
   expect_lint("stats:::sdd(c(1,2,3))",
     NULL,
     namespace_linter(check_nonexports = FALSE))
+
+  expect_lint("stats::sd(c(1,2,3))\nstats::sdd(c(1,2,3))",
+    list(line = "stats::sdd(c(1,2,3))"),
+    namespace_linter())
 })


### PR DESCRIPTION
This PR changes the following linters based on XML parse data so that they only work with full parse data:

* `missing_package_linter`
* `namespace_linter`
* `missing_argument_linter`

and `file_lines` is used instead of `lines` which was incorrect (missing `line` in results).