### PR TITLE
Change reporting of lints in GHA

### DIFF
--- a/R/actions.R
+++ b/R/actions.R
@@ -5,9 +5,12 @@ in_github_actions <- function() {
 # Output logging commands for any lints found
 github_actions_log_lints <- function(lints) {
   for (x in lints) {
-    cat(
-      sprintf("::warning file=%s,line=%s,col=%s::%s\n", x$filename, x$line_number, x$column_number, x$message),
-      sep = ""
+    file_line_col <- sprintf(
+      "file=%s,line=%s,col=%s", x$filename, x$line_number, x$column_number
     )
+    cat(sprintf(
+      "::warning %s::%s,%s\n",
+      file_line_col, file_line_col, x$message
+    ), sep = "")
   }
 }


### PR DESCRIPTION
Closes #558

Reports the linting via a GHA annotation (a warning) but also puts file and line details into the log