### PR TITLE
Make inline data work in RStudio

### DIFF
--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -45,7 +45,7 @@ expect_lint <- function(content, checks, ..., file = NULL, language = "en") {
 
   if (is.null(file)) {
     file <- tempfile()
-    on.exit(unlink(file))
+    on.exit(unlink(file), add = TRUE)
     writeLines(content, con = file, sep = "\n")
   }
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -378,11 +378,23 @@ rstudio_source_markers <- function(lints) {
   })
 
   # request source markers
-  rstudioapi::callFun("sourceMarkers",
-                      name = "lintr",
-                      markers = markers,
-                      basePath = package_path,
-                      autoSelect = "first")
+  out <- rstudioapi::callFun(
+    "sourceMarkers",
+    name = "lintr",
+    markers = markers,
+    basePath = package_path,
+    autoSelect = "first"
+  )
+
+  # workaround to avoid focusing an empty Markers pane
+  # when possible, better solution is to delete the "lintr" source marker list
+  # https://github.com/rstudio/rstudioapi/issues/209
+  if (length(lints) == 0) {
+    Sys.sleep(0.1)
+    rstudioapi::executeCommand("activateConsole")
+  }
+
+  out
 }
 
 #' Checkstyle Report for lint results

--- a/R/lint.R
+++ b/R/lint.R
@@ -28,7 +28,7 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
   if (inline_data) {
     content <- gsub("\n$", "", filename)
     filename <- tempfile()
-    on.exit(unlink(filename))
+    on.exit(unlink(filename), add = TRUE)
     writeLines(text = content, con = filename, sep = "\n")
   }
 

--- a/R/methods.R
+++ b/R/methods.R
@@ -52,9 +52,12 @@ markdown <- function(x, info, ...) {
 
 #' @export
 print.lints <- function(x, ...) {
+  rstudio_source_markers <- getOption("lintr.rstudio_source_markers", TRUE) &&
+    rstudioapi::hasFun("sourceMarkers")
+
   if (length(x)) {
-    if (getOption("lintr.rstudio_source_markers", TRUE) &&
-        rstudioapi::hasFun("sourceMarkers")) {
+    inline_data <- x[[1]][["filename"]] == "<text>"
+    if (!inline_data && rstudio_source_markers) {
       rstudio_source_markers(x)
     } else if (in_github_actions()) {
       github_actions_log_lints(x)
@@ -78,8 +81,7 @@ print.lints <- function(x, ...) {
     if (isTRUE(settings$error_on_lint)) {
       quit("no", 31, FALSE)
     }
-  } else if (getOption("lintr.rstudio_source_markers", TRUE) &&
-             rstudioapi::hasFun("sourceMarkers")) {
+  } else if (rstudio_source_markers) {
     # Empty lints: clear RStudio source markers
     rstudio_source_markers(x)
   }

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -99,3 +99,20 @@ test_that("print.lint works", {
   )
   expect_output(print(l), "  1:length(x)", fixed = TRUE)
 })
+
+test_that("print.lint works for inline data, even in RStudio", {
+  l <- lint("x = 1\n")
+
+  withr::with_options(
+    list("lintr.rstudio_source_markers" = FALSE),
+    expect_output(print(l), "not =")
+  )
+
+  withr::with_options(
+    list("lintr.rstudio_source_markers" = TRUE),
+    with_mock(
+      `rstudioapi::hasFun` = function(...) TRUE,
+      expect_output(print(l), "not =")
+    )
+  )
+})

--- a/tests/testthat/test-rstudio_markers.R
+++ b/tests/testthat/test-rstudio_markers.R
@@ -1,93 +1,94 @@
 context("rstudio_source_markers")
 test_that("it returns markers which match lints", {
-  with_mock(`rstudioapi::callFun` = function(...) return(list(...)),
-    lint1 <- structure(
-      list(
-        Lint(filename = "test_file",
-          line_number = 1,
-          column_number = 2,
-          type = "error",
-          line = "a line",
-          message = "hi")
-        ),
-      class = "lints"
-      ),
-    marker1 <- rstudio_source_markers(lint1),
+  lint1 <- structure(
+    list(
+      Lint(filename = "test_file",
+           line_number = 1,
+           column_number = 2,
+           type = "error",
+           line = "a line",
+           message = "hi")
+    ),
+    class = "lints"
+  )
+  with_mock(
+    `rstudioapi::callFun` = function(...) list(...),
+    `rstudioapi::executeCommand` = function(...) NULL,
+    marker1 <- rstudio_source_markers(lint1)
+  )
+  expect_equal(marker1$name, "lintr")
+  expect_equal(marker1$markers[[1]]$type, lint1[[1]]$type)
+  expect_equal(marker1$markers[[1]]$file, lint1[[1]]$filename)
+  expect_equal(marker1$markers[[1]]$line, lint1[[1]]$line_number)
+  expect_equal(marker1$markers[[1]]$column, lint1[[1]]$column_number)
+  expect_equal(marker1$markers[[1]]$message, lint1[[1]]$message)
 
-    expect_equal(marker1$name, "lintr"),
-    expect_equal(marker1$markers[[1]]$type, lint1[[1]]$type),
-    expect_equal(marker1$markers[[1]]$file, lint1[[1]]$filename),
-    expect_equal(marker1$markers[[1]]$line, lint1[[1]]$line_number),
-    expect_equal(marker1$markers[[1]]$column, lint1[[1]]$column_number),
-    expect_equal(marker1$markers[[1]]$message, lint1[[1]]$message),
-
-    lint2 <- structure(
-      list(
-        Lint(filename = "test_file",
-          line_number = 1,
-          column_number = 2,
-          type = "error",
-          line = "a line",
-          message = "hi"),
-        Lint(filename = "test_file2",
-          line_number = 10,
-          column_number = 5,
-          type = "warning",
-          message = "test a message")
-        ),
-      class = "lints"
-      ),
-
-    marker2 <- rstudio_source_markers(lint2),
-
-    expect_equal(marker2$name, "lintr"),
-    expect_equal(marker2$markers[[1]]$type, lint2[[1]]$type),
-    expect_equal(marker2$markers[[1]]$file, lint2[[1]]$filename),
-    expect_equal(marker2$markers[[1]]$line, lint2[[1]]$line_number),
-    expect_equal(marker2$markers[[1]]$column, lint2[[1]]$column_number),
-    expect_equal(marker2$markers[[1]]$message, lint2[[1]]$message),
-
-    expect_equal(marker2$name, "lintr"),
-    expect_equal(marker2$markers[[2]]$type, lint2[[2]]$type),
-    expect_equal(marker2$markers[[2]]$file, lint2[[2]]$filename),
-    expect_equal(marker2$markers[[2]]$line, lint2[[2]]$line_number),
-    expect_equal(marker2$markers[[2]]$column, lint2[[2]]$column_number),
-    expect_equal(marker2$markers[[2]]$message, lint2[[2]]$message)
-  )})
+  lint2 <- structure(
+    list(
+      Lint(filename = "test_file",
+           line_number = 1,
+           column_number = 2,
+           type = "error",
+           line = "a line",
+           message = "hi"),
+      Lint(filename = "test_file2",
+           line_number = 10,
+           column_number = 5,
+           type = "warning",
+           message = "test a message")
+    ),
+    class = "lints"
+  )
+  with_mock(
+    `rstudioapi::callFun` = function(...) list(...),
+    `rstudioapi::executeCommand` = function(...) NULL,
+    marker2 <- rstudio_source_markers(lint2)
+  )
+  expect_equal(marker2$name, "lintr")
+  expect_equal(marker2$markers[[1]]$type, lint2[[1]]$type)
+  expect_equal(marker2$markers[[1]]$file, lint2[[1]]$filename)
+  expect_equal(marker2$markers[[1]]$line, lint2[[1]]$line_number)
+  expect_equal(marker2$markers[[1]]$column, lint2[[1]]$column_number)
+  expect_equal(marker2$markers[[1]]$message, lint2[[1]]$message)
+})
 
 test_that("it prepends the package path if it exists", {
-  with_mock(`rstudioapi::callFun` = function(...) return(list(...)),
-    lint3 <- structure(
-      list(
-        Lint(filename = "test_file",
-          line_number = 1,
-          column_number = 2,
-          type = "error",
-          line = "a line",
-          message = "hi")
-        ),
-      class = "lints",
-      path = "test"
-      ),
-    marker3 <- rstudio_source_markers(lint3),
-    expect_equal(marker3$name, "lintr"),
-    expect_equal(marker3$basePath, "test"), # nolint
-    expect_equal(marker3$markers[[1]]$type, lint3[[1]]$type),
-    expect_equal(marker3$markers[[1]]$file, file.path("test", lint3[[1]]$filename)),
-    expect_equal(marker3$markers[[1]]$line, lint3[[1]]$line_number),
-    expect_equal(marker3$markers[[1]]$column, lint3[[1]]$column_number),
-    expect_equal(marker3$markers[[1]]$message, lint3[[1]]$message)
-  )
-})
-test_that("it returns an empty list of markers if there are no lints", {
-  with_mock(`rstudioapi::callFun` = function(...) return(list(...)),
-    lint4 <- structure(
-      list(),
-      class = "lints"
+  lint3 <- structure(
+    list(
+      Lint(filename = "test_file",
+           line_number = 1,
+           column_number = 2,
+           type = "error",
+           line = "a line",
+           message = "hi")
     ),
-    marker4 <- rstudio_source_markers(lint4),
-
-    expect_equal(marker4$name, "lintr"),
-    expect_equal(marker4$markers, list())
+    class = "lints",
+    path = "test"
   )
+  with_mock(
+    `rstudioapi::callFun` = function(...) list(...),
+    `rstudioapi::executeCommand` = function(...) NULL,
+    marker3 <- rstudio_source_markers(lint3)
+  )
+  expect_equal(marker3$name, "lintr")
+  expect_equal(marker3$basePath, "test") # nolint
+  expect_equal(marker3$markers[[1]]$type, lint3[[1]]$type)
+  expect_equal(marker3$markers[[1]]$file, file.path("test", lint3[[1]]$filename))
+  expect_equal(marker3$markers[[1]]$line, lint3[[1]]$line_number)
+  expect_equal(marker3$markers[[1]]$column, lint3[[1]]$column_number)
+  expect_equal(marker3$markers[[1]]$message, lint3[[1]]$message)
+})
+
+test_that("it returns an empty list of markers if there are no lints", {
+  lint4 <- structure(
+    list(),
+    class = "lints"
+  )
+  with_mock(
+    `rstudioapi::callFun` = function(...) list(...),
+    `rstudioapi::executeCommand` = function(...) NULL,
+    marker4 <- rstudio_source_markers(lint4)
+  )
+  expect_equal(marker4$name, "lintr")
+  expect_equal(marker4$markers, list())
 })


### PR DESCRIPTION
~(#589 should be merged first)~ *done*

Thanks to @jimhester I now know it's possible to provide to-be-linted source directly to `lint()` by passing a string with a newline.

But printing the resulting lints doesn't work in RStudio, because there's no underlying source file. It looks something like this:

```
> library(lintr)
> linter <- undesirable_function_linter(fun = c("dir" = NA))
> lintr::lint('dir(".")\n', linter)
Error in .rs.normalizePath(marker$file, mustWork = TRUE) : 
  path[1]="<text>": No such file or directory
```

whereas this is what you see outside the IDE:

```
library(lintr)
linter <- undesirable_function_linter(fun = c("dir" = NA))
lint('dir(".")\n', linter)
#> <text>:1:1: warning: Function "dir" is undesirable.
#> dir(".")
#> ^~~
```

This PR makes lint printing work in RStudio, even when the source code was inlined (vs. came from a source file).