### PR TITLE
apply some linters to R/

### DIFF
--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -22,7 +22,7 @@ cyclocomp_linter <- function(complexity_limit = 25) {
       type = "style",
       message = paste0(
         "functions should have cyclomatic complexity of less than ",
-        complexity_limit, ", this has ", complexity,"."
+        complexity_limit, ", this has ", complexity, "."
       ),
       ranges = list(c(source_file[["column"]][1], source_file[["column"]][1])),
       line = source_file$lines[1],

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -373,7 +373,7 @@ fix_eq_assigns <- function(pc) {
 
   prev_locs <- vapply(eq_assign_locs, prev_with_parent, pc = pc, integer(1))
   next_locs <- vapply(eq_assign_locs, next_with_parent, pc = pc, integer(1))
-  expr_locs <- (function(x){
+  expr_locs <- (function(x) {
     x[is.na(x)] <- FALSE
     !x
     })(prev_locs == lag(next_locs)) # nolint

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -23,7 +23,7 @@ object_name_linter <- function(styles = "snake_case") {
     "Variable and function name style should be ", .or_string(styles), "."
   )
 
-  function (source_file) {
+  function(source_file) {
     x <- global_xml_parsed_content(source_file)
     if (is.null(x)) {
       return()
@@ -120,7 +120,7 @@ make_object_linter <- function(fun) {
     token_nums <- ids_with_token(
       source_file, rex(start, "SYMBOL" %if_next_isnt% "_SUB"), fun=re_matches
     )
-    if(length(token_nums) == 0){
+    if (length(token_nums) == 0) {
       return(list())
     }
     tokens <- with_id(source_file, token_nums)
@@ -136,7 +136,6 @@ make_object_linter <- function(fun) {
       keep_indices,
       function(i) {
         token <- tokens[i, ]
-        name <- names[i]
         if (is_declared_here(token, source_file) &&
             !is_external_reference(source_file, token[["id"]])) {
           fun(source_file, token)

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -29,11 +29,9 @@ object_usage_linter <-  function(source_file) {
   symbols <- get_assignment_symbols(source_file$xml_parsed_content)
 
   # Just assign them an empty function
-  for(symbol in symbols) {
+  for (symbol in symbols) {
     assign(symbol, function(...) invisible(), envir = env)
   }
-
-  all_globals <- unique(recursive_ls(env))
 
   fun_info <- get_function_assignments(source_file$xml_parsed_content)
 
@@ -128,7 +126,7 @@ parse_check_usage <- function(expression) {
 
   vals <- list()
 
-  report <- function (x) {
+  report <- function(x) {
     vals[[length(vals) + 1L]] <<- x
   }
 

--- a/R/semicolon_terminator_linter.R
+++ b/R/semicolon_terminator_linter.R
@@ -45,4 +45,3 @@ is_trailing_sc <- function(sc_tokens, source_file) {
   tail_str <- substr(line_str, sc_tokens[["col1"]] + 1L, nchar(line_str))
   grepl("^\\s*(#|}|\\z)", tail_str, perl = TRUE)
 }
-

--- a/R/undesirable_operator_linter.R
+++ b/R/undesirable_operator_linter.R
@@ -44,4 +44,3 @@ undesirable_operator_linter <- function(op=default_undesirable_operators) {
     )
   }
 }
-


### PR DESCRIPTION
Part of #584 

I applied several linters across R/ here:

 - `commas_linter`
 - `trailing_blank_lines_linter`
 - `spaces_left_parentheses_linter`
 - `object_usage_linter`
 - `function_left_parentheses_linter`
 - `paren_brace_linter`

I skipped `equals_na_linter` which only gives a spurious match that would be fixed by #546. Similarly there's a spurious instance of `paren_brace_linter` that applies to it's own source where `"){"` is present. We should move that linter to match on the parse tree as well.