### PR TITLE
Rename xml_parsed_content for the full file

### DIFF
--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -29,9 +29,8 @@
 #'           for .Rmd scripts, this is the extracted R source code (as text)}
 #'     \item{`full_parsed_content` (`data.frame`) as given by
 #'           [utils::getParseData()] for the full content}
-#'     \item{`xml_parsed_content` (`xml_document`) the XML parse tree of all
+#'     \item{`full_xml_parsed_content` (`xml_document`) the XML parse tree of all
 #'           expressions as given by [xmlparsedata::xml_parse_data()]}
-#'     \item{`is_full_file` (`TRUE`) records that this
 #'     \item{`terminal_newline` (`logical`) records whether `filename` has a terminal
 #'           newline (as determined by [readLines()] producing a corresponding warning)}
 #'   }
@@ -170,8 +169,7 @@ get_source_expressions <- function(filename) {
       file_lines = source_file$lines,
       content = source_file$lines,
       full_parsed_content = parsed_content,
-      xml_parsed_content = if (!is.null(parsed_content)) tryCatch(xml2::read_xml(xmlparsedata::xml_parse_data(parsed_content)), error = function(e) NULL),
-      is_full_file = TRUE,
+      full_xml_parsed_content = if (!is.null(parsed_content)) tryCatch(xml2::read_xml(xmlparsedata::xml_parse_data(parsed_content)), error = function(e) NULL),
       terminal_newline = terminal_newline
     )
 
@@ -200,8 +198,7 @@ get_single_source_expression <- function(loc,
     xml_parsed_content = tryCatch(xml2::read_xml(xmlparsedata::xml_parse_data(pc)), error = function(e) NULL),
     content = content,
     find_line = find_line_fun(content),
-    find_column = find_column_fun(content),
-    is_full_file = FALSE
+    find_column = find_column_fun(content)
   )
 }
 

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -31,6 +31,7 @@
 #'           [utils::getParseData()] for the full content}
 #'     \item{`xml_parsed_content` (`xml_document`) the XML parse tree of all
 #'           expressions as given by [xmlparsedata::xml_parse_data()]}
+#'     \item{`is_full_file` (`TRUE`) records that this
 #'     \item{`terminal_newline` (`logical`) records whether `filename` has a terminal
 #'           newline (as determined by [readLines()] producing a corresponding warning)}
 #'   }
@@ -170,6 +171,7 @@ get_source_expressions <- function(filename) {
       content = source_file$lines,
       full_parsed_content = parsed_content,
       xml_parsed_content = if (!is.null(parsed_content)) tryCatch(xml2::read_xml(xmlparsedata::xml_parse_data(parsed_content)), error = function(e) NULL),
+      is_full_file = TRUE,
       terminal_newline = terminal_newline
     )
 
@@ -198,7 +200,8 @@ get_single_source_expression <- function(loc,
     xml_parsed_content = tryCatch(xml2::read_xml(xmlparsedata::xml_parse_data(pc)), error = function(e) NULL),
     content = content,
     find_line = find_line_fun(content),
-    find_column = find_column_fun(content)
+    find_column = find_column_fun(content),
+    is_full_file = FALSE
   )
 }
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -75,7 +75,6 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
 
   for (expr in source_expressions$expressions) {
     for (linter in names(linters)) {
-      cat("lintr:", linter, "\n")
       if (isTRUE(cache) && has_lint(lint_cache, expr, linter)) {
         lints[[itr <- itr + 1L]] <- retrieve_lint(lint_cache, expr, linter, source_expressions$lines)
       }

--- a/R/lint.R
+++ b/R/lint.R
@@ -75,6 +75,7 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
 
   for (expr in source_expressions$expressions) {
     for (linter in names(linters)) {
+      cat("lintr:", linter, "\n")
       if (isTRUE(cache) && has_lint(lint_cache, expr, linter)) {
         lints[[itr <- itr + 1L]] <- retrieve_lint(lint_cache, expr, linter, source_expressions$lines)
       }

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -4,9 +4,9 @@
 missing_argument_linter <- function(except = c("switch", "alist")) {
   function(source_file) {
 
-    if (is.null(source_file$xml_parsed_content)) return(list())
+    if (is.null(source_file$full_xml_parsed_content)) return(list())
 
-    xml <- source_file$xml_parsed_content
+    xml <- source_file$full_xml_parsed_content
 
     xpath <- "//expr[expr[SYMBOL_FUNCTION_CALL]]/*[
       self::OP-COMMA[preceding-sibling::*[1][self::OP-LEFT-PAREN or self::OP-COMMA]] or

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -4,7 +4,7 @@
 missing_argument_linter <- function(except = c("switch", "alist")) {
   function(source_file) {
 
-    if (!length(source_file$full_parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
+    if (is.null(source_file$xml_parsed_content)) return(list())
 
     xml <- source_file$xml_parsed_content
 

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -3,7 +3,7 @@
 #' @export
 missing_package_linter <- function(source_file) {
 
-  if (!length(source_file$full_parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
+  if (is.null(source_file$xml_parsed_content)) return(list())
 
   xml <- source_file$xml_parsed_content
 

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -3,9 +3,9 @@
 #' @export
 missing_package_linter <- function(source_file) {
 
-  if (is.null(source_file$xml_parsed_content)) return(list())
+  if (is.null(source_file$full_xml_parsed_content)) return(list())
 
-  xml <- source_file$xml_parsed_content
+  xml <- source_file$full_xml_parsed_content
 
   library_calls <- c("library", "require", "loadNamespace", "requireNamespace")
 

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -8,7 +8,7 @@
 #' @export
 namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
   function(source_file) {
-    if (!length(source_file$full_parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
+    if (is.null(source_file$xml_parsed_content)) return(list())
 
     xml <- source_file$xml_parsed_content
 

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -8,9 +8,9 @@
 #' @export
 namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
   function(source_file) {
-    if (is.null(source_file$xml_parsed_content)) return(list())
+    if (is.null(source_file$full_xml_parsed_content)) return(list())
 
-    xml <- source_file$xml_parsed_content
+    xml <- source_file$full_xml_parsed_content
 
     ns_nodes <- xml2::xml_find_all(xml, "//expr/*[self::NS_GET or self::NS_GET_INT]")
 

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -195,6 +195,7 @@ is_external_reference <- function(source_file, id) {
   any(sibling_tokens %in% c("NS_GET", "NS_GET_INT"))
 }
 
+# via unlist(tools:::.get_standard_package_names(), use.names = FALSE)
 base_pkgs <- c(
   "base",
   "tools",

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -9,7 +9,7 @@ object_usage_linter <-  function(source_file) {
   }
 
   # If there is no xml data just return
-  if (is.null(source_file$xml_parsed_content)) {
+  if (is.null(source_file$full_xml_parsed_content)) {
     return()
   }
 
@@ -26,14 +26,14 @@ object_usage_linter <-  function(source_file) {
 
   declared_globals <- try_silently(utils::globalVariables(package = pkg_name %||% globalenv()))
 
-  symbols <- get_assignment_symbols(source_file$xml_parsed_content)
+  symbols <- get_assignment_symbols(source_file$full_xml_parsed_content)
 
   # Just assign them an empty function
   for (symbol in symbols) {
     assign(symbol, function(...) invisible(), envir = env)
   }
 
-  fun_info <- get_function_assignments(source_file$xml_parsed_content)
+  fun_info <- get_function_assignments(source_file$full_xml_parsed_content)
 
   lapply(seq_len(NROW(fun_info)), function(i) {
     info <- fun_info[i, ]
@@ -84,15 +84,21 @@ object_usage_linter <-  function(source_file) {
 }
 
 get_assignment_symbols <- function(xml) {
-  left_assignment_symbols <- xml2::xml_text(xml2::xml_find_all(xml, "expr[LEFT_ASSIGN]/expr[1]/*"))
+  left_assignment_symbols <-
+    xml2::xml_text(xml2::xml_find_all(xml, "expr[LEFT_ASSIGN]/expr[1]/*"))
+  equal_assignment_symbols <-
+    xml2::xml_text(xml2::xml_find_all(xml, "equal_assign/expr[1]/*"))
+  assign_fun_symbols <-
+    xml2::xml_text(xml2::xml_find_all(xml, "expr[expr[SYMBOL_FUNCTION_CALL/text()='assign']]/expr[2]/*"))
+  set_method_fun_symbols <-
+    xml2::xml_text(xml2::xml_find_all(xml, "expr[expr[SYMBOL_FUNCTION_CALL/text()='setMethod']]/expr[2]/*"))
 
-  equal_assignment_symbols <- xml2::xml_text(xml2::xml_find_all(xml, "equal_assign/expr[1]/*"))
-
-  assign_fun_symbols <- xml2::xml_text(xml2::xml_find_all(xml, "expr[expr[SYMBOL_FUNCTION_CALL/text()='assign']]/expr[2]/*"))
-
-  set_method_fun_symbols <- xml2::xml_text(xml2::xml_find_all(xml, "expr[expr[SYMBOL_FUNCTION_CALL/text()='setMethod']]/expr[2]/*"))
-
-  symbols <- c(left_assignment_symbols, equal_assignment_symbols, assign_fun_symbols, set_method_fun_symbols)
+  symbols <- c(
+    left_assignment_symbols,
+    equal_assignment_symbols,
+    assign_fun_symbols,
+    set_method_fun_symbols
+  )
 
   # remove quotes or backticks from the beginning or the end
   symbols <- gsub("^[`'\"]|['\"`]$", "", symbols)
@@ -101,15 +107,21 @@ get_assignment_symbols <- function(xml) {
 }
 
 get_function_assignments <- function(xml) {
-  left_assignment_functions <- xml2::xml_find_all(xml, "expr[LEFT_ASSIGN][expr[2][FUNCTION]]/expr[2]")
+  left_assignment_functions <-
+      xml2::xml_find_all(xml, "expr[LEFT_ASSIGN][expr[2][FUNCTION]]/expr[2]")
+  equal_assignment_functions <-
+      xml2::xml_find_all(xml, "equal_assign[expr[2]][expr[FUNCTION]]/expr[2]")
+  assign_fun_assignment_functions <-
+      xml2::xml_find_all(xml, "expr[expr[SYMBOL_FUNCTION_CALL/text()='assign']]/expr[3]")
+  set_method_fun_assignment_functions <-
+      xml2::xml_find_all(xml, "expr[expr[SYMBOL_FUNCTION_CALL/text()='setMethod']]/expr[3]")
 
-  equal_assignment_functions <- xml2::xml_find_all(xml, "equal_assign[expr[2]][expr[FUNCTION]]/expr[2]")
-
-  assign_fun_assignment_functions <- xml2::xml_find_all(xml, "expr[expr[SYMBOL_FUNCTION_CALL/text()='assign']]/expr[3]")
-
-  set_method_fun_assignment_functions <- xml2::xml_find_all(xml, "expr[expr[SYMBOL_FUNCTION_CALL/text()='setMethod']]/expr[3]")
-
-  funs <- c(left_assignment_functions, equal_assignment_functions, assign_fun_assignment_functions, set_method_fun_assignment_functions)
+  funs <- c(
+    left_assignment_functions,
+    equal_assignment_functions,
+    assign_fun_assignment_functions,
+    set_method_fun_assignment_functions
+  )
 
   get_attr <- function(x, attr) as.integer(xml2::xml_attr(x, attr))
 

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -6,7 +6,7 @@
 #' @export
 seq_linter <- function(source_file) {
 
-  if (!length(source_file$parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
+  if (is.null(source_file$xml_parsed_content)) return(list())
 
   xml <- source_file$xml_parsed_content
 

--- a/R/sprintf_linter.R
+++ b/R/sprintf_linter.R
@@ -2,9 +2,9 @@
 #'    arguments with incompatible types in \code{sprintf} calls.
 #' @export
 sprintf_linter <- function(source_file) {
-  if (is.null(source_file$xml_parsed_content)) return(list())
+  if (is.null(source_file$full_xml_parsed_content)) return(list())
 
-  xml <- source_file$xml_parsed_content
+  xml <- source_file$full_xml_parsed_content
 
   xpath <- "//expr[
     expr/SYMBOL_FUNCTION_CALL[text() = 'sprintf'] and

--- a/R/sprintf_linter.R
+++ b/R/sprintf_linter.R
@@ -2,7 +2,7 @@
 #'    arguments with incompatible types in \code{sprintf} calls.
 #' @export
 sprintf_linter <- function(source_file) {
-  if (!length(source_file$full_parsed_content) || is.null(source_file$xml_parsed_content)) return(list())
+  if (is.null(source_file$xml_parsed_content)) return(list())
 
   xml <- source_file$xml_parsed_content
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -144,15 +144,9 @@ trim_ws <- function(x) {
   attr(x, name, exact = TRUE)
 }
 
-global_parsed_content <- function(source_file) {
-  if (exists("file_lines", source_file)) {
-    source_file$parsed_content
-  }
-}
-
 global_xml_parsed_content <- function(source_file) {
   if (exists("file_lines", source_file)) {
-    source_file$xml_parsed_content
+    source_file$full_xml_parsed_content
   }
 }
 

--- a/tests/testthat/default_linter_testcode.R
+++ b/tests/testthat/default_linter_testcode.R
@@ -18,7 +18,7 @@ f = function (x,y = 1){}
 # object_name
 # object_usage
 # open_curly
-someComplicatedFunctionWithALongCameCaseName <- function(x)
+someComplicatedFunctionWithALongCamelCaseName <- function(x)
 {
   y <- 1
 	if (1 > 2 && 2 > 3 && 3 > 4 && 4 > 5 && 5*10 > 6 && x == NA) {TRUE} else {FALSE}

--- a/tests/testthat/dummy_packages/package/R/default_linter_testcode.R
+++ b/tests/testthat/dummy_packages/package/R/default_linter_testcode.R
@@ -18,7 +18,7 @@ f = function (x,y = 1){}
 # object_name
 # object_usage
 # open_curly
-someComplicatedFunctionWithALongCameCaseName <- function(x)
+someComplicatedFunctionWithALongCamelCaseName <- function(x)
 {
   y <- 1
   if (1 > 2 && 2 > 3 && 3 > 4 && 4 > 5 && 5*10 > 6 && x == NA) {TRUE} else {FALSE}

--- a/tests/testthat/dummy_packages/package/data-raw/default_linter_testcode.R
+++ b/tests/testthat/dummy_packages/package/data-raw/default_linter_testcode.R
@@ -18,7 +18,7 @@ f = function (x,y = 1){}
 # object_name
 # object_usage
 # open_curly
-someComplicatedFunctionWithALongCameCaseName <- function(x)
+someComplicatedFunctionWithALongCamelCaseName <- function(x)
 {
   y <- 1
   if (1 > 2 && 2 > 3 && 3 > 4 && 4 > 5 && 5*10 > 6 && x == NA) {TRUE} else {FALSE}

--- a/tests/testthat/dummy_packages/package/inst/data-raw/default_linter_testcode.R
+++ b/tests/testthat/dummy_packages/package/inst/data-raw/default_linter_testcode.R
@@ -18,7 +18,7 @@ f = function (x,y = 1){}
 # object_name
 # object_usage
 # open_curly
-someComplicatedFunctionWithALongCameCaseName <- function(x)
+someComplicatedFunctionWithALongCamelCaseName <- function(x)
 {
   y <- 1
   if (1 > 2 && 2 > 3 && 3 > 4 && 4 > 5 && 5*10 > 6 && x == NA) {TRUE} else {FALSE}


### PR DESCRIPTION
Closes #608 

Renaming entailed fixing some logic that relied on the name being `xml_parsed_content`. In every case I think the new code is cleaner.

Also tidied a few things in the midst of fixing tests that were breaking:

 - line width lint applied to `get_assignment_symbols` and `get_function_assignments` in `object_usage_linter`
 - `global_parsed_content` in `utils` is unused. Also, it's wrong (it should be `source_file$full_parsed_content`), so I just deleted it.
 - minor typo in some test files: `someComplicatedFunctionWithALongCameCaseName` -> `someComplicatedFunctionWithALongCamelCaseName`

TODO:

 - [x] Test against downstream `goodpractice`

tested both CRAN & GitHub master:

```
install.packages('goodpractice')
tools::testInstalledPackage('goodpractice')

# restart
remotes::install_github("MangoTheCat/goodpractice")
tools::testInstalledPackage('goodpractice')
```

Both passed