### PR TITLE
enable open_curly_linter in .lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,7 @@
 linters: with_defaults(
   line_length_linter(120),
-  open_curly_linter
-)
+  open_curly_linter)
+
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,
   "inst/example/bad.R",

--- a/.lintr
+++ b/.lintr
@@ -3,7 +3,6 @@ linters: with_defaults( # The following TODOs are part of an effort to have {lin
    infix_spaces_linter = NULL, # TODO enable (#594)
    commented_code_linter = NULL, # TODO enable (#595)
    cyclocomp_linter = cyclocomp_linter(29), # TODO reduce to 15
-   open_curly_linter,
    object_name_linter = NULL, # TODO enable (#597)
    spaces_inside_linter = NULL, # TODO enable (#598)
    closed_curly_linter = NULL, # TODO enable (#599)

--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,7 @@
-linters: with_defaults(line_length_linter(120))
+linters: with_defaults(
+  line_length_linter(120),
+  open_curly_linter
+)
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,
   "inst/example/bad.R",

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -51,7 +51,7 @@ expect_lint <- function(content, checks, ..., file = NULL, language = "en") {
 
   lints <- lint(file, ...)
   n_lints <- length(lints)
-  lint_str <- if (n_lints) {paste0(c("", lints), collapse="\n")} else {""}
+  lint_str <- if (n_lints) paste0(c("", lints), collapse="\n") else ""
 
   wrong_number_fmt  <- "got %d lints instead of %d%s"
   if (is.null(checks)) {

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -42,8 +42,7 @@
 get_source_expressions <- function(filename) {
   source_file <- srcfile(filename)
   terminal_newline <- TRUE
-  source_file$lines <- withCallingHandlers(
-    {
+  source_file$lines <- withCallingHandlers({
       readLines(filename)
     },
     warning = function(w) {
@@ -316,7 +315,7 @@ fix_tab_indentations <- function(source_file) {
   tab_cols <- gregexpr("\t", source_file[["lines"]], fixed = TRUE)
   names(tab_cols) <- seq_along(tab_cols)
   tab_cols <- tab_cols[!is.na(tab_cols)]  # source lines from .Rmd and other files are NA
-  tab_cols <- lapply(tab_cols, function(x) {if (x[[1L]] < 0L) {NA} else {x}})
+  tab_cols <- lapply(tab_cols, function(x) {if (x[[1L]] < 0L) NA else x})
   tab_cols <- tab_cols[!is.na(tab_cols)]
 
   if (!length(tab_cols)) {

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -315,7 +315,7 @@ fix_tab_indentations <- function(source_file) {
   tab_cols <- gregexpr("\t", source_file[["lines"]], fixed = TRUE)
   names(tab_cols) <- seq_along(tab_cols)
   tab_cols <- tab_cols[!is.na(tab_cols)]  # source lines from .Rmd and other files are NA
-  tab_cols <- lapply(tab_cols, function(x) {if (x[[1L]] < 0L) NA else x})
+  tab_cols <- lapply(tab_cols, function(x) if (x[[1L]] < 0L) NA else x)
   tab_cols <- tab_cols[!is.na(tab_cols)]
 
   if (!length(tab_cols)) {

--- a/R/spaces_inside_linter.R
+++ b/R/spaces_inside_linter.R
@@ -40,7 +40,7 @@ spaces_inside_linter <- function(source_file) {
               Lint(
                 filename = source_file$filename,
                 line_number = line_number,
-                column_number = if (substr(line, start, start) == " ") {start} else {start + 1L},
+                column_number = if (substr(line, start, start) == " ") start else start + 1L,
                 type = "style",
                 message = "Do not place spaces around code in parentheses or square brackets.",
                 line = line,

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -21,7 +21,7 @@ unneeded_concatenation_linter <- function(source_file) {
           line_number = line_num,
           column_number = start_col_num,
           type = "warn",
-          message = if (num_args) {msg_const} else {msg_empty},
+          message = if (num_args) msg_const else msg_empty,
           line = line,
           linter = "unneeded_concatenation_linter",
           ranges = list(c(start_col_num, end_col_num))


### PR DESCRIPTION
Closes #596

There are already no lints for this linter, we just need to enable it in the options:

```
lintr::lint_package(linters = lintr::open_curly_linter)
# returns nothing
```