### PR TITLE
Allow .onLoad and other special functions regardless of name style

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * New `sprintf_linter()` (#544, #578, @renkun-ken)
 * Exclusions specified in the `.lintr` file are now relative to the location of that file 
   and support excluding entire directories (#158, #438, @AshesITR)
+* `object_name_linter()` now excludes special R functions such as `.onLoad` (#500, #614, @AshesITR)
 
 # lintr 2.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
 * New `sprintf_linter()` (#544, #578, @renkun-ken)
 * Exclusions specified in the `.lintr` file are now relative to the location of that file 
   and support excluding entire directories (#158, #438, @AshesITR)
-* `object_name_linter()` now excludes special R functions such as `.onLoad` (#500, #614, @AshesITR)
+* `object_name_linter()` now excludes special R hook functions such as `.onLoad` (#500, #614, @AshesITR)
 
 # lintr 2.0.1
 

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -240,6 +240,7 @@ is_base_function <- function(x) {
   x %in% base_funs
 }
 
+# see ?".onLoad" and ?"Startup"
 special_funs <- c(
   ".onLoad",
   ".onAttach",

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -129,7 +129,8 @@ make_object_linter <- function(fun) {
     keep_indices <- which(
       !is_operator(names) &
         !is_known_generic(names) &
-        !is_base_function(names)
+        !is_base_function(names) &
+        !is_special_function(names)
     )
 
     lapply(
@@ -237,6 +238,20 @@ base_funs <- unlist(lapply(base_pkgs,
 
 is_base_function <- function(x) {
   x %in% base_funs
+}
+
+special_funs <- c(
+  ".onLoad",
+  ".onAttach",
+  ".onUnload",
+  ".onDetach",
+  ".Last.lib",
+  ".First",
+  ".Last"
+)
+
+is_special_function <- function(x) {
+  x %in% special_funs
 }
 
 object_lint <- function(source_file, token, message, type) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -182,7 +182,7 @@ default_settings <- NULL
 
 settings <- NULL
 
-.onLoad <- function(libname, pkgname) { # nolint
+.onLoad <- function(libname, pkgname) {
   op <- options()
   op.lintr <- list(
     lintr.linter_file = ".lintr"


### PR DESCRIPTION
Also remove relevant # nolint in lintrs own .onLoad.

fixes #500