### PR TITLE
enable commend_code_linter and apply it

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,6 @@
 linters: with_defaults( # The following TODOs are part of an effort to have {lintr} lint-free (#584)
    line_length_linter = line_length_linter(120),
    infix_spaces_linter = NULL, # TODO enable (#594)
-   commented_code_linter = NULL, # TODO enable (#595)
    cyclocomp_linter = cyclocomp_linter(29), # TODO reduce to 15
    object_name_linter = NULL, # TODO enable (#597)
    spaces_inside_linter = NULL, # TODO enable (#598)

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -327,16 +327,16 @@ fix_column_numbers <- function(content) {
 # getParseData() counts 1 tab as a variable number of spaces instead of one:
 # https://github.com/wch/r-source/blame/e7401b68ab0e032fce3e376aaca9a5431619b2b4/src/main/gram.y#L512
 # The number of spaces is so that the code is brought to the next 8-character indentation level e.g:
-#   "1\t;"          -> "1       ;"
-#   "12\t;"         -> "12      ;"
-#   "123\t;"        -> "123     ;"
-#   "1234\t;"       -> "1234    ;"
-#   "12345\t;"      -> "12345   ;"
-#   "123456\t;"     -> "123456  ;"
-#   "1234567\t;"    -> "1234567 ;"
-#   "12345678\t;"   -> "12345678        ;"
-#   "123456789\t;"  -> "123456789       ;"
-#   "1234567890\t;" -> "1234567890      ;"
+#   "1\t;"          --> "1       ;"
+#   "12\t;"         --> "12      ;"
+#   "123\t;"        --> "123     ;"
+#   "1234\t;"       --> "1234    ;"
+#   "12345\t;"      --> "12345   ;"
+#   "123456\t;"     --> "123456  ;"
+#   "1234567\t;"    --> "1234567 ;"
+#   "12345678\t;"   --> "12345678        ;"
+#   "123456789\t;"  --> "123456789       ;"
+#   "1234567890\t;" --> "1234567890      ;"
 fix_tab_indentations <- function(source_file) {
   pc <- getParseData(source_file)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -194,9 +194,9 @@ escape_chars <- c(
   "\\f"  = "\f",  # form feed
   "\\v"  = "\v"   # vertical tab
   # dynamically-added:
-  #"\\'"  = "'",  # ASCII apostrophe
-  #"\\\"" = "\"", # ASCII quotation mark
-  #"\\`"  = "`"   # ASCII grave accent (backtick)
+  #"\\'"  --> "'",  # ASCII apostrophe
+  #"\\\"" --> "\"", # ASCII quotation mark
+  #"\\`"  --> "`"   # ASCII grave accent (backtick)
 )
 
 unescape <- function(str, q="`") {


### PR DESCRIPTION
Closes #595 

in utils.R it's "code-code" whereas in get_source_expressions.R it is only incidentally code (treating `->` as right assignment).

In both cases I used `-->` (which doesn't parse as code), not sure if this is ideal for the utils.R case.