### PR TITLE
added lint-changed-files CI workflow

### DIFF
--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -37,7 +37,6 @@ jobs:
           remotes::install_cran("gh")
           remotes::install_github("jimhester/lintr")
           remotes::install_cran("purrr")
-          remotes::install_cran("fs")
         shell: Rscript {0}
 
       - name: Add lintr options
@@ -49,7 +48,5 @@ jobs:
           files <- gh::gh("GET https://api.github.com/repos/jimhester/lintr/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
           files_to_lint <- changed_files[grepl(".R$|.Rmd$", changed_files)]
-          all_files <- fs::dir_ls(recurse = TRUE, glob = ".R$|.Rmd$")
-          exclusions_list <- as.list(setdiff(all_files, files_to_lint))
-          lintr::lint_package(exclusions = exclusions_list)
+          for (f in files_to_lint) { print(lintr::lint(f)) }
         shell: Rscript {0}

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -4,10 +4,10 @@ on:
       - main
       - master
 
-name: lint changed files
+name: lint-changed-files
 
 jobs:
-  lintr:
+  lint-changed-files:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
           files <- gh::gh("GET https://api.github.com/repos/jimhester/lintr/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
           files_to_lint <- changed_files[grepl(".R$|.Rmd$", changed_files)]
-          all_files <- fs::dir_ls(recurse = TRUE, glob = ".Rmd|.R")
+          all_files <- fs::dir_ls(recurse = TRUE, glob = ".R$|.Rmd$")
           exclusions_list <- as.list(setdiff(all_files, files_to_lint))
           lintr::lint_package(exclusions = exclusions_list)
         shell: Rscript {0}

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -1,0 +1,55 @@
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+name: lint changed files
+
+jobs:
+  lintr:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("gh")
+          remotes::install_github("jimhester/lintr")
+          remotes::install_cran("purrr")
+          remotes::install_cran("fs")
+        shell: Rscript {0}
+
+      - name: Add lintr options
+        run: cat('\noptions(lintr.linter_file = ".lintr_new")\n', file = "~/.Rprofile", append = TRUE)
+        shell: Rscript {0}
+
+      - name: Extract and lint files changed by this PR
+        run: |
+          files <- gh::gh("GET https://api.github.com/repos/jimhester/lintr/pulls/${{ github.event.pull_request.number }}/files")
+          changed_files <- purrr::map_chr(files, "filename")
+          files_to_lint <- changed_files[grepl(".R$|.Rmd$", changed_files)]
+          all_files <- fs::dir_ls(recurse = TRUE, glob = ".Rmd|.R")
+          exclusions_list <- as.list(setdiff(all_files, files_to_lint))
+          lintr::lint_package(exclusions = exclusions_list)
+        shell: Rscript {0}

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -47,6 +47,7 @@ jobs:
         run: |
           files <- gh::gh("GET https://api.github.com/repos/jimhester/lintr/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
-          files_to_lint <- changed_files[grepl(".R$|.Rmd$", changed_files)]
-          for (f in files_to_lint) { print(lintr::lint(f)) }
+          all_files <- list.files(recursive = TRUE)
+          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          lintr::lint_package(exclusions = exclusions_list)
         shell: Rscript {0}

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -37,7 +37,6 @@ jobs:
           remotes::install_cran("gh")
           remotes::install_github("jimhester/lintr")
           remotes::install_cran("purrr")
-          remotes::install_cran("fs")
         shell: Rscript {0}
 
       - name: Add lintr options
@@ -48,7 +47,6 @@ jobs:
         run: |
           files <- gh::gh("GET https://api.github.com/repos/jimhester/lintr/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
-          all_files <- fs::dir_ls(recurse = TRUE)
-          exclusions_list <- as.list(setdiff(all_files, changed_files))
-          lintr::lint_package(exclusions = exclusions_list)
+          files_to_lint <- changed_files[grepl(".R$|.Rmd$", changed_files)]
+          for (f in files_to_lint) { print(lintr::lint(f)) }
         shell: Rscript {0}

--- a/.github/workflows/lint-changed-files.yaml
+++ b/.github/workflows/lint-changed-files.yaml
@@ -37,6 +37,7 @@ jobs:
           remotes::install_cran("gh")
           remotes::install_github("jimhester/lintr")
           remotes::install_cran("purrr")
+          remotes::install_cran("fs")
         shell: Rscript {0}
 
       - name: Add lintr options
@@ -47,6 +48,7 @@ jobs:
         run: |
           files <- gh::gh("GET https://api.github.com/repos/jimhester/lintr/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
-          files_to_lint <- changed_files[grepl(".R$|.Rmd$", changed_files)]
-          for (f in files_to_lint) { print(lintr::lint(f)) }
+          all_files <- fs::dir_ls(recurse = TRUE)
+          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          lintr::lint_package(exclusions = exclusions_list)
         shell: Rscript {0}

--- a/.lintr_new
+++ b/.lintr_new
@@ -1,0 +1,11 @@
+linters: with_defaults(
+    line_length_linter = line_length_linter(120),
+    T_and_F_symbol_linter = T_and_F_symbol_linter
+  )
+exclusions: list(
+  "tests/testthat/dummy_packages",
+  "tests/testthat/knitr_formats",
+  "tests/testthat/knitr_malformed",
+  "inst",
+  "vignettes"
+ )

--- a/.lintr_new
+++ b/.lintr_new
@@ -1,6 +1,5 @@
 linters: with_defaults(
-    line_length_linter = line_length_linter(120),
-    T_and_F_symbol_linter = T_and_F_symbol_linter
+    line_length_linter = line_length_linter(120)
   )
 exclusions: list(
   "tests/testthat/dummy_packages",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # lintr (development version)
 
+* Added a secondary, more restrictive lint workflow - `lint-changed-files` - for newly written / modified code (#641, @dragosmg) 
 * Switched CI from Travis to GitHub Actions, using the full tidyverse recommended R CMD check. Code coverage and linting are implemented using separate GitHub Actions workflows (#572, @dragosmg)
 * `save_cache` will now recursively create the cache directory; this avoids errors that could arise if any parent directories do not exist (#60, @dankessler).
 * `extract_r_source` handles Rmd containing unevaluated code blocks with named


### PR DESCRIPTION
closes #641 

still to-do:

- [x] name for the secondary `lintr` config file - it will be named `.lintr_new`
- [x] content of the secondary config file - content added as
```
linters: with_defaults(
    line_length_linter = line_length_linter(120),
    T_and_F_symbol_linter = T_and_F_symbol_linter
  )
exclusions: list(
  "tests/testthat/dummy_packages",
  "tests/testthat/knitr_formats",
  "tests/testthat/knitr_malformed",
  "inst",
  "vignettes"
 )
```
- [x] ~check the double exclusion of files gives the intended result~
- [x] change the `lint` workflow to exclude changed files (linted here)? - no, the main lint workflow will be left as is
- [x] add news note?