### PR TITLE
permit new error message (R-devel)

### DIFF
--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -39,10 +39,25 @@ test_that("returns the correct linting", {
     equals_na_linter
   )
 
+  # Error message changed in R-devel as of 2020/12
+  old_lang <- Sys.getenv("LANG")
+  Sys.setenv(LANG = "en")
+  on.exit(Sys.setenv(LANG = old_lang), add = TRUE)
+  expected_message <- tryCatch(parse(text = "\\"), error = function(e) {
+    rex::re_substitutes(
+      data = conditionMessage(e),
+      pattern = rex::rex(
+        list(start, "<text>:1:1: ") %or%
+          list(newline, anything, newline, anything, end)
+      ),
+      replacement = "",
+      global = TRUE
+    )
+  })
+
   expect_lint(
     "\\",
-    # Error message changed in R-devel as of 2020/12
-    rex("unexpected input" %or% "unexpected end of line")
+    rex(expected_message)
   )
 
   expect_lint("``",

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -40,9 +40,9 @@ test_that("returns the correct linting", {
   )
 
   # Error message changed in R-devel as of 2020/12
-  old_lang <- Sys.getenv("LANG")
-  Sys.setenv(LANG = "en")
-  on.exit(Sys.setenv(LANG = old_lang), add = TRUE)
+  old_lang <- Sys.getenv("LANGUAGE")
+  Sys.setenv(LANGUAGE = "en")
+  on.exit(Sys.setenv(LANGUAGE = old_lang), add = TRUE)
   expected_message <- tryCatch(parse(text = "\\"), error = function(e) {
     rex::re_substitutes(
       data = conditionMessage(e),

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -39,8 +39,10 @@ test_that("returns the correct linting", {
     equals_na_linter
   )
 
-  expect_lint("\\",
-    rex("unexpected input")
+  expect_lint(
+    "\\",
+    # Error message changed in R-devel as of 2020/12
+    rex("unexpected input" %or% "unexpected end of line")
   )
 
   expect_lint("``",

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -47,7 +47,7 @@ test_that("returns the correct linting", {
     rex::re_substitutes(
       data = conditionMessage(e),
       pattern = rex::rex(
-        list(start, "<text>:1:1: ") %or%
+        list(start, "<text>:", any_digits, ":", any_digits, ": ") %or%
           list(newline, anything, newline, anything, end)
       ),
       replacement = "",


### PR DESCRIPTION
Currently, CI builds on r-devel are failing because the parser error message for input `\` changed from "unexpected input" to "unexpected end of line".