### PR TITLE
Coverage for utils.R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -74,18 +74,6 @@ auto_names <- function(x) {
   nms
 }
 
-quoted_blanks <- function(matches, shift_start = 0, shift_end = 0) {
-  lengths <- nchar(matches)
-  blanks <- vapply(Map(rep.int,
-      rep.int(" ", length(lengths - (shift_start + shift_end))),
-      lengths - (shift_start + shift_end), USE.NAMES = FALSE),
-    paste, "", collapse = "")
-
-  substr(matches, shift_start + 1L, nchar(matches) - shift_end) <- blanks
-  matches
-}
-
-
 # The following functions is from dplyr
 names2 <- function(x) {
   names(x) %||% rep("", length(x))

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -57,6 +57,24 @@ test_that("with_defaults works as expected", {
 })
 
 test_that("rot utility works as intended", {
-  rot <- lintr:::rot
-  expect_equal(rot(letters), c(letters[14:26], LETTERS[1:13]))
+  expect_equal(lintr:::rot(letters), c(letters[14:26], LETTERS[1:13]))
+})
+
+test_that("logical_env utility works as intended", {
+  test_env <- "LINTR_TEST_LOGICAL_ENV_"
+  sym_set_env <- function(key, value) do.call(Sys.setenv, setNames(list(value), key))
+  old = Sys.getenv(test_env, unset = NA)
+  on.exit(if (is.na(old)) Sys.unsetenv(test_env) else sym_set_env(test_env, old))
+
+  sym_set_env(test_env, 'true')
+  expect_equal(lintr:::logical_env(test_env), TRUE)
+
+  sym_set_env(test_env, 'F')
+  expect_equal(lintr:::logical_env(test_env), FALSE)
+
+  sym_set_env(test_env, '')
+  expect_null(lintr:::logical_env(test_env))
+
+  Sys.unsetenv(test_env)
+  expect_null(lintr:::logical_env(test_env))
 })


### PR DESCRIPTION
One line is uncovered, it's unreachable currently. The `xml_nodes_to_lint` helper only applies to `equals_na_linter`, which always matches the node with `==` or `!=`, which can't be split over multiple lines.

In the future this helper could apply to linters where the line split is possible, so I'll leave it as uncovered for now (no need for `# nocov`, and I don't see a need to use `:::` to test it directly if we can avoid it)