### PR TITLE
Include "demo" directory in `lint_package`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 * `unneeded_concatenation_linter` now correctly considers arguments piped in via magrittr `%>%` (#573, #585, @michaelquinn32)
 * Set the default `complexity_limit` in `cyclocomp_linter` to 15. This is the same complexity limit that is enforced via
   `default_linters` (#693, #695, @AshesITR).
+* `lint_package()` now lints files in the `demo` directory by default (#703, @dmurdoch).
 
 # lintr 2.0.1
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -267,7 +267,7 @@ lint_package <- function(path = ".", relative_path = TRUE, ...,
     pattern = pattern
   )
 
-  lints <- lint_dir(file.path(path, c("R", "tests", "inst", "vignettes", "data-raw")),
+  lints <- lint_dir(file.path(path, c("R", "tests", "inst", "vignettes", "data-raw", "demo")),
                     relative_path = FALSE, exclusions = exclusions, parse_settings = FALSE, ...)
 
   if (isTRUE(relative_path)) {


### PR DESCRIPTION
Demos are typically R code, so should be linted.