### PR TITLE
enable `paren_brace_linter` for {lintr}

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,6 @@
 linters: with_defaults( # The following TODOs are part of an effort to have {lintr} lint-free (#584)
    line_length_linter = line_length_linter(120),
-   cyclocomp_linter = cyclocomp_linter(30), # TODO reduce to 15
-   paren_brace_linter = NULL # TODO enable (#603)
+   cyclocomp_linter = cyclocomp_linter(30) # TODO reduce to 15
  )
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,


### PR DESCRIPTION
Fixes #603

No lints were observed with `paren_brace_linter` on the code base.