### PR TITLE
Docs: inline code for lint function

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -12,15 +12,27 @@ NULL
 #' Lint a file
 #'
 #' Apply one or more linters to a file and return the lints found.
+#'
 #' @name lint_file
-#' @param filename the given filename to lint.
-#' @param linters a named list of linter functions to apply see \code{\link{linters}}
-#' for a full list of default and available linters.
+#'
+#' @param filename either the filename for a file to lint, or a character
+#' string of inline R code for linting. If a newline character is detected,
+#' this will be assumed to be inline code.
+#' @param linters a named list of linter functions to apply see
+#' \code{\link{linters}} for a full list of default and available linters.
 #' @param cache given a logical, toggle caching of lint results. If passed a
 #' character string, store the cache in this directory.
 #' @param ... additional arguments passed to \code{\link{exclude}}.
-#' @param parse_settings whether to try and parse the settings
+#' @param parse_settings whether to try and parse the settings.
+#'
 #' @return A list of lint objects.
+#'
+#' @examples
+#' \dontrun{
+#'   lint("some/file-name.R") # linting a file
+#'   lint("a = 123\n")        # linting inline-code
+#' }
+#'
 #' @export
 lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = TRUE) {
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -16,8 +16,8 @@ NULL
 #' @name lint_file
 #'
 #' @param filename either the filename for a file to lint, or a character
-#' string of inline R code for linting. If a newline character is detected,
-#' this will be assumed to be inline code.
+#' string of inline R code for linting. The latter [inline data] applies
+#' whenever \code{filename} has a newline character (\\n).
 #' @param linters a named list of linter functions to apply see
 #' \code{\link{linters}} for a full list of default and available linters.
 #' @param cache given a logical, toggle caching of lint results. If passed a

--- a/man/lint_dir.Rd
+++ b/man/lint_dir.Rd
@@ -32,7 +32,7 @@ package path.}
 the extensions .R, .Rmd, .Rnw, .Rhtml, .Rrst, .Rtex, .Rtxt allowing for
 lowercase r (.r, ...)}
 
-\item{parse_settings}{whether to try and parse the settings}
+\item{parse_settings}{whether to try and parse the settings.}
 }
 \value{
 A list of lint objects.

--- a/man/lint_file.Rd
+++ b/man/lint_file.Rd
@@ -8,21 +8,30 @@
 lint(filename, linters = NULL, cache = FALSE, ..., parse_settings = TRUE)
 }
 \arguments{
-\item{filename}{the given filename to lint.}
+\item{filename}{either the filename for a file to lint, or a character
+string of inline R code for linting. If a newline character is detected,
+this will be assumed to be inline code.}
 
-\item{linters}{a named list of linter functions to apply see \code{\link{linters}}
-for a full list of default and available linters.}
+\item{linters}{a named list of linter functions to apply see
+\code{\link{linters}} for a full list of default and available linters.}
 
 \item{cache}{given a logical, toggle caching of lint results. If passed a
 character string, store the cache in this directory.}
 
 \item{...}{additional arguments passed to \code{\link{exclude}}.}
 
-\item{parse_settings}{whether to try and parse the settings}
+\item{parse_settings}{whether to try and parse the settings.}
 }
 \value{
 A list of lint objects.
 }
 \description{
 Apply one or more linters to a file and return the lints found.
+}
+\examples{
+\dontrun{
+  lint("some/file-name.R") # linting a file
+  lint("a = 123\n")        # linting inline-code
+}
+
 }

--- a/man/lint_file.Rd
+++ b/man/lint_file.Rd
@@ -9,8 +9,8 @@ lint(filename, linters = NULL, cache = FALSE, ..., parse_settings = TRUE)
 }
 \arguments{
 \item{filename}{either the filename for a file to lint, or a character
-string of inline R code for linting. If a newline character is detected,
-this will be assumed to be inline code.}
+string of inline R code for linting. The latter [inline data] applies
+whenever \code{filename} has a newline character (\\n).}
 
 \item{linters}{a named list of linter functions to apply see
 \code{\link{linters}} for a full list of default and available linters.}

--- a/man/lint_package.Rd
+++ b/man/lint_package.Rd
@@ -26,7 +26,7 @@ absolute path.}
 \item{exclusions}{exclusions for \code{\link{exclude}}, relative to the
 package path.}
 
-\item{parse_settings}{whether to try and parse the settings}
+\item{parse_settings}{whether to try and parse the settings.}
 }
 \value{
 A list of lint objects.


### PR DESCRIPTION
Fixes #712 and #474

Add description of use of inline R code in the filename argument of `lint()`