### PR TITLE
Closed-curly typo

### DIFF
--- a/R/closed_curly_linter.R
+++ b/R/closed_curly_linter.R
@@ -5,60 +5,64 @@
 #' @export
 closed_curly_linter <- function(allow_single_line = FALSE) {
   function(source_file) {
-    lapply(ids_with_token(source_file, "'}'"),
-           function(id) {
+    lapply(
+      ids_with_token(source_file, "'}'"),
+      function(id) {
 
-             parsed <- with_id(source_file, id)
+        parsed <- with_id(source_file, id)
+        parsed_content <- source_file[["parsed_content"]]
 
-             tokens_before <- source_file$parsed_content$token[
-                                                               source_file$parsed_content$line1 == parsed$line1 &
-                                                               source_file$parsed_content$col1 < parsed$col1]
+        tokens_before <- parsed_content$token[
+                                              parsed_content$line1 == parsed$line1 &
+                                              parsed_content$col1 < parsed$col1]
 
-             tokens_after <- source_file$parsed_content$token[
-                                                              source_file$parsed_content$line1 == parsed$line1 &
-                                                              source_file$parsed_content$col1 > parsed$col1]
-             if (isTRUE(allow_single_line) &&
-                 "'{'" %in% tokens_before) {
-               return()
-             }
+        tokens_after <- parsed_content$token[
+                                             parsed_content$line1 == parsed$line1 &
+                                             parsed_content$col1 > parsed$col1]
+        if (isTRUE(allow_single_line) &&
+            "'{'" %in% tokens_before) {
+          return()
+        }
 
-             if (length(tokens_after) &&
-                 tokens_after[[1]] %in% c("')'", "','")) {
-               return()
-             }
+        if (length(tokens_after) &&
+            tokens_after[[1]] %in% c("')'", "','")) {
+          return()
+        }
 
-             has_expression_before <- any(tokens_before %in% "expr")
+        has_expression_before <- any(tokens_before %in% "expr")
 
-             has_expression_after <- any(tokens_after %in% "expr")
+        has_expression_after <- any(tokens_after %in% "expr")
 
-             has_else_after <- any(tokens_after %in% "ELSE")
+        has_else_after <- any(tokens_after %in% "ELSE")
 
-             line <- source_file$lines[as.character(parsed$line1)]
-             content_after <- unname(substr(line, parsed$col1 + 1L, nchar(line)))
-             content_before <- unname(substr(line, 1, parsed$col1 - 1L))
+        line <- source_file$lines[as.character(parsed$line1)]
+        content_after <- unname(substr(line, parsed$col1 + 1L, nchar(line)))
+        content_before <- unname(substr(line, 1, parsed$col1 - 1L))
 
-             double_curly <- rex::re_matches(content_after, rex::rex(start, "}")) ||
-               rex::re_matches(content_before, rex::rex("}", end))
+        double_curly <- rex::re_matches(content_after, rex::rex(start, "}")) ||
+          rex::re_matches(content_before, rex::rex("}", end))
 
-             if (double_curly) {
-               return()
-             }
+        if (double_curly) {
+          return()
+        }
 
-             # if the closing curly has an expression on the same line, and there is
-             # not also an else
-             if (has_expression_before ||
-                 has_expression_after && !has_else_after) {
-               Lint(
-                    filename = source_file$filename,
-                    line_number = parsed$line1,
-                    column_number = parsed$col1,
-                    type = "style",
-                    message = "Closing curly-braces should always be on their own line, unless it's followed by an else.", # nolint
-                    line = source_file$lines[as.character(parsed$line1)],
-                    linter = "closed_curly_linter"
-                    )
-             }
-
-           })
+        # If the closing curly has an expression on the same line, and there is
+        # not also an else
+        if (has_expression_before ||
+            has_expression_after && !has_else_after) {
+          Lint(
+            filename = source_file$filename,
+            line_number = parsed$line1,
+            column_number = parsed$col1,
+            type = "style",
+            message = paste(
+              "Closing curly-braces should always be on their own line,",
+              "unless it's followed by an else."
+            ),
+            line = source_file$lines[as.character(parsed$line1)],
+            linter = "closed_curly_linter"
+          )}
+      }
+    )
   }
 }

--- a/R/closed_curly_linter.R
+++ b/R/closed_curly_linter.R
@@ -57,7 +57,7 @@ closed_curly_linter <- function(allow_single_line = FALSE) {
             type = "style",
             message = paste(
               "Closing curly-braces should always be on their own line,",
-              "unless it's followed by an else."
+              "unless they are followed by an else."
             ),
             line = source_file$lines[as.character(parsed$line1)],
             linter = "closed_curly_linter"

--- a/tests/testthat/test-closed_curly_linter.R
+++ b/tests/testthat/test-closed_curly_linter.R
@@ -1,3 +1,10 @@
+closed_curly_message_regex <- rex(
+  paste(
+    "Closing curly-braces should always be on their own line,",
+    "unless it's followed by an else."
+  )
+)
+
 test_that("returns the correct linting", {
 
   expect_lint("blah",
@@ -9,11 +16,11 @@ test_that("returns the correct linting", {
     closed_curly_linter())
 
   expect_lint("a <- function() { 1 }",
-    rex("Closing curly-braces should always be on their own line, unless it's followed by an else."),
+    closed_curly_message_regex,
     closed_curly_linter())
 
   expect_lint("a <- function() { 1 }",
-    rex("Closing curly-braces should always be on their own line, unless it's followed by an else."),
+    closed_curly_message_regex,
     closed_curly_linter())
 
   expect_lint("a <- function() { 1 }",
@@ -21,18 +28,18 @@ test_that("returns the correct linting", {
               closed_curly_linter(allow_single_line = TRUE))
 
   expect_lint("a <- if(1) {\n 1} else {\n 2\n}",
-    rex("Closing curly-braces should always be on their own line, unless it's followed by an else."),
+    closed_curly_message_regex,
     closed_curly_linter())
 
   expect_lint("a <- if(1) {\n 1\n} else {\n 2}",
-    rex("Closing curly-braces should always be on their own line, unless it's followed by an else."),
+    closed_curly_message_regex,
     closed_curly_linter())
 
   expect_lint("a <- if(1) {\n 1} else {\n 2}",
     list(
-      rex("Closing curly-braces should always be on their own line, unless it's followed by an else."),
-      rex("Closing curly-braces should always be on their own line, unless it's followed by an else.")
-      ),
+      closed_curly_message_regex,
+      closed_curly_message_regex
+    ),
     closed_curly_linter())
 
   expect_lint("eval(bquote({...}))",

--- a/tests/testthat/test-closed_curly_linter.R
+++ b/tests/testthat/test-closed_curly_linter.R
@@ -1,11 +1,9 @@
-closed_curly_message_regex <- rex(
-  paste(
-    "Closing curly-braces should always be on their own line,",
-    "unless they are followed by an else."
-  )
-)
-
 test_that("returns the correct linting", {
+  closed_curly_message_regex <- rex(
+    paste(
+      "Closing curly-braces should always be on their own line,",
+      "unless they are followed by an else."
+    ))
 
   expect_lint("blah",
     NULL,

--- a/tests/testthat/test-closed_curly_linter.R
+++ b/tests/testthat/test-closed_curly_linter.R
@@ -1,7 +1,7 @@
 closed_curly_message_regex <- rex(
   paste(
     "Closing curly-braces should always be on their own line,",
-    "unless it's followed by an else."
+    "unless they are followed by an else."
   )
 )
 

--- a/tests/testthat/test-closed_curly_linter.R
+++ b/tests/testthat/test-closed_curly_linter.R
@@ -24,8 +24,8 @@ test_that("returns the correct linting", {
     closed_curly_linter())
 
   expect_lint("a <- function() { 1 }",
-              NULL,
-              closed_curly_linter(allow_single_line = TRUE))
+    NULL,
+    closed_curly_linter(allow_single_line = TRUE))
 
   expect_lint("a <- if(1) {\n 1} else {\n 2\n}",
     closed_curly_message_regex,
@@ -43,16 +43,16 @@ test_that("returns the correct linting", {
     closed_curly_linter())
 
   expect_lint("eval(bquote({...}))",
-              NULL,
-              closed_curly_linter())
+    NULL,
+    closed_curly_linter())
 
   expect_lint("fun({\n  statements\n}, param)",
-              NULL,
-              closed_curly_linter())
+    NULL,
+    closed_curly_linter())
 
   expect_lint("out <- lapply(stuff, function(i) {\n  do_something(i)\n}) %>% unlist",
-              NULL,
-              closed_curly_linter())
+    NULL,
+    closed_curly_linter())
 
   expect_lint("{{x}}", NULL, closed_curly_linter())
 })


### PR DESCRIPTION
Fixes a plurality typo in the lint message for closed-curly linter (and in the tests for the same).

Previously it said "Closed curly braces should [blah] unless it's followed by ..."
Now it says "Closed curly braces should [blah] unless they are followed by ..."

Also, some pre-emptive refactoring of closed-curly linter prior to addressing it's cyclomatic complexity (to be a separate PR):
- changed indentation to 2-spaces
- reduced duplication in use of "source_file$parsed_content"
- reduced duplication of `rex(the-closed-curly-linter-message)` across the tests for closed-curly-linter