### PR TITLE
docs: add linter-names to ?default_linters

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -69,7 +69,15 @@ with_defaults <- function(..., default = default_linters) {
 
 #' Default linters
 #'
-#' List of default linters for \code{\link{lint}}. Use \code{\link{with_defaults}} to customize it.
+#' @description List of default linters for \code{\link{lint}}. Use
+#' \code{\link{with_defaults}} to customize it.
+#'
+#' The set of default linters is as follows (any parameterised linters, eg,
+#' \code{line_length_linter} use their default argument(s), see \code{?
+#' <linter_name>} for details):
+#'
+#' - \Sexpr[stage=render, results=rd]{paste(names(lintr::default_linters), collapse=", ")}.
+#'
 #' @export
 default_linters <- with_defaults(
   default = list(),

--- a/man/default_linters.Rd
+++ b/man/default_linters.Rd
@@ -11,6 +11,13 @@ An object of class \code{list} of length 24.
 default_linters
 }
 \description{
-List of default linters for \code{\link{lint}}. Use \code{\link{with_defaults}} to customize it.
+List of default linters for \code{\link{lint}}. Use
+\code{\link{with_defaults}} to customize it.
+
+The set of default linters is as follows (any parameterised linters, eg,
+\code{line_length_linter} use their default argument(s), see \code{?
+<linter_name>} for details):
+
+- \Sexpr[stage=render, results=rd]{paste(names(lintr::default_linters), collapse=", ")}.
 }
 \keyword{datasets}


### PR DESCRIPTION
Fixes #510

Appends the names of the default-linters to the manpage for `default_linters`.