### PR TITLE
Ignore `renv` and `packrat` by default in lint_dir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * New `sprintf_linter()` (#544, #578, #624, #625, @renkun-ken, @AshesITR)
 * Exclusions specified in the `.lintr` file are now relative to the location of that file 
   and support excluding entire directories (#158, #438, @AshesITR)
+* `lint_dir()` excludes the `renv` and `packrat` directories by default (#697, @AshesITR)
 * `object_name_linter()` now excludes special R hook functions such as `.onLoad` 
   (#500, #614, @AshesITR and @michaelchirico)
 * `equals_na_linter()` now lints `x != NA` and `NA == x`, and skips usages in comments (#545, @michaelchirico)

--- a/R/lint.R
+++ b/R/lint.R
@@ -172,7 +172,7 @@ reorder_lints <- function(lints) {
 #'   )
 #' }
 #' @export
-lint_dir <- function(path = ".", relative_path = TRUE, ..., exclusions = NULL,
+lint_dir <- function(path = ".", relative_path = TRUE, ..., exclusions = list("renv", "packrat"),
                      pattern = rex::rex(
                        ".", one_of("Rr"),
                        or("", "html", "md", "nw", "rst", "tex", "txt"),

--- a/man/lint_dir.Rd
+++ b/man/lint_dir.Rd
@@ -8,7 +8,7 @@ lint_dir(
   path = ".",
   relative_path = TRUE,
   ...,
-  exclusions = NULL,
+  exclusions = list("renv", "packrat"),
   pattern = rex::rex(".", one_of("Rr"), or("", "html", "md", "nw", "rst", "tex",
     "txt"), end),
   parse_settings = TRUE


### PR DESCRIPTION
fixes #697