### PR TITLE
Remove spurious # nolints

### DIFF
--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -412,7 +412,7 @@ fix_eq_assigns <- function(pc) {
   expr_locs <- (function(x) {
     x[is.na(x)] <- FALSE
     !x
-    })(prev_locs == lag(next_locs)) # nolint
+    })(prev_locs == lag(next_locs))
 
   id_itr <- max(pc$id)
 

--- a/R/open_curly_linter.R
+++ b/R/open_curly_linter.R
@@ -49,7 +49,10 @@ open_curly_linter <- function(allow_single_line = FALSE) {
                     line_number = parsed$line1,
                     column_number = parsed$col1,
                     type = "style",
-                    message = "Opening curly braces should never go on their own line and should always be followed by a new line.", # nolint
+                    message = paste(
+                      "Opening curly braces should never go on their own line and",
+                      "should always be followed by a new line."
+                    ),
                     line = line,
                     linter = "open_curly_linter"
                     )

--- a/tests/testthat/test-deprecated.R
+++ b/tests/testthat/test-deprecated.R
@@ -4,7 +4,7 @@ expect_quiet_lint <- function(...) {
 
 test_that("absolute_paths_linter() returns the correct linting", {
   expect_quiet_lint("blah", NULL, absolute_paths_linter)
-  expect_quiet_lint("'/blah/file.txt'", # nolint
+  expect_quiet_lint("'/blah/file.txt'",
                     rex("Do not use absolute paths."),
                     absolute_paths_linter)
 })

--- a/tests/testthat/test-rstudio_markers.R
+++ b/tests/testthat/test-rstudio_markers.R
@@ -70,7 +70,7 @@ test_that("it prepends the package path if it exists", {
     marker3 <- rstudio_source_markers(lint3)
   )
   expect_equal(marker3$name, "lintr")
-  expect_equal(marker3$basePath, "test") # nolint
+  expect_equal(marker3$basePath, "test")
   expect_equal(marker3$markers[[1]]$type, lint3[[1]]$type)
   expect_equal(marker3$markers[[1]]$file, file.path("test", lint3[[1]]$filename))
   expect_equal(marker3$markers[[1]]$line, lint3[[1]]$line_number)


### PR DESCRIPTION
Closes #672.

Three specific `# nolint`s remain in the source:

```
./R/T_and_F_symbol_linter.R:T_and_F_symbol_linter <- function(source_file) { # nolint: object_name_linter.
./R/lint.R:Lint <- function(filename, line_number = 1L, column_number = 1L, # nolint: object_name_linter.
./R/function_left_parentheses.R:function_left_parentheses_linter <- function(source_file) { # nolint: object_length_linter.
```