### PR TITLE
Anchor to opening brace instead of closing paren in paren_brace_linter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 * New `backport_linter()` for detecting mismatched R version dependencies (#506, @MichaelChirico)
 * `paren_brace_linter` and `no_tab_linter` also use more reliable matching (e.g.,
   excluding matches found in comments; #441 and #545, @russHyde)
+* `paren_brace_linter` now marks lints at the opening brace instead of the closing parenthesis, making fixing the lints
+  by jumping to source markers easier (#583, @AshesITR)
 * Lints are now marked with the name of the `linter` that caused them instead of the name of their implementation
   function (#664, #673, @AshesITR).
 * New syntax to exclude only selected linters from linting lines or passages. Use `# nolint: linter_name, linter2_name.`

--- a/R/paren_brace_linter.R
+++ b/R/paren_brace_linter.R
@@ -12,9 +12,9 @@ paren_brace_linter <- function(source_file) {
 
   xpath <- paste(
     "//OP-LEFT-BRACE[",
-      "@line1 = preceeding-sibling::expr/OP-RIGHT-PAREN/@line1",
+      "@line1 = parent::expr/preceding-sibling::OP-RIGHT-PAREN/@line1",
       "and",
-      "@col1 = preceeding-sibling::expr/OP-RIGHT-PAREN/@col1 + 1",
+      "@col1 = parent::expr/preceding-sibling::OP-RIGHT-PAREN/@col1 + 1",
     "]"
   )
 

--- a/R/paren_brace_linter.R
+++ b/R/paren_brace_linter.R
@@ -11,10 +11,10 @@ paren_brace_linter <- function(source_file) {
   xml <- source_file$xml_parsed_content
 
   xpath <- paste(
-    "//OP-RIGHT-PAREN[",
-      "@line1 = following-sibling::expr/OP-LEFT-BRACE/@line1",
+    "//OP-LEFT-BRACE[",
+      "@line1 = preceeding-sibling::expr/OP-RIGHT-PAREN/@line1",
       "and",
-      "@col1 = following-sibling::expr/OP-LEFT-BRACE/@col1 - 1",
+      "@col1 = preceeding-sibling::expr/OP-RIGHT-PAREN/@col1 + 1",
     "]"
   )
 

--- a/tests/testthat/test-paren_brace_linter.R
+++ b/tests/testthat/test-paren_brace_linter.R
@@ -7,13 +7,19 @@ test_that("returns the correct linting", {
 
   expect_lint(
     "blah <- function(){}",
-    msg,
+    list(
+      message = msg,
+      column_number = 19L
+    ),
     paren_brace_linter
   )
 
   expect_lint(
     "\nblah <- function(){\n\n\n}",
-    msg,
+    list(
+      message = msg,
+      column_number = 19L
+    ),
     paren_brace_linter
   )
 


### PR DESCRIPTION
fixes #583

- [x] implement
- [ ] update tests to check lint location as well