### PR TITLE
Fix R CMD check NOTEs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,7 +8,9 @@
 ^cran-comments\.md$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^\.idea$
 ^\.lintr$
+^\.lintr_new$
 ^wercker\.yml$
 ^[^/]+.Rmd$
 ^revdep$
@@ -19,4 +21,4 @@
 ^\.covrignore$
 ^script[.]R$
 ^bench$
-^tests/testthat/package/[.]Rbuildignore$
+^tests/testthat/dummy_packages/package/[.]Rbuildignore$

--- a/R/lint.R
+++ b/R/lint.R
@@ -277,7 +277,7 @@ lint_package <- function(path = ".", relative_path = TRUE, ...,
   exclusions <- normalize_exclusions(
     c(exclusions, settings$exclusions),
     root = path,
-    pattern = pattern
+    pattern = NULL
   )
 
   lints <- lint_dir(file.path(path, c("R", "tests", "inst", "vignettes", "data-raw", "demo")),

--- a/R/lint.R
+++ b/R/lint.R
@@ -276,8 +276,7 @@ lint_package <- function(path = ".", relative_path = TRUE, ...,
 
   exclusions <- normalize_exclusions(
     c(exclusions, settings$exclusions),
-    root = path,
-    pattern = NULL
+    root = path
   )
 
   lints <- lint_dir(file.path(path, c("R", "tests", "inst", "vignettes", "data-raw", "demo")),


### PR DESCRIPTION
 * Use `pattern = NULL` in `lint_package()` fixes #631
 * Update `.Rbuildignore` to reflect recent changes:
   - added `.lintr_new`
   - moved ignore for `tests/testthat/package/.Rbuildignore` to  
     new location `tests/testthat/dummy_packages/package/.Rbuildignore`
   - added `.idea` (IntelliJ Project Metadata)