### PR TITLE
add trailing_blank_lines lint at end of file if terminal_newline is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@
   `default_linters` (#693, #695, @AshesITR).
 * `lint_package()` now lints files in the `demo` directory by default (#703, @dmurdoch).
 * `commented_code_linter()` uses the parse tree to find comments, eliminating some false positives (#451, @AshesITR)
+* `trailing_blank_lines_linter()` now also lints if a trailing blank line is missing (#675, @AshesITR)
 
 # lintr 2.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,7 +48,7 @@
   `default_linters` (#693, #695, @AshesITR).
 * `lint_package()` now lints files in the `demo` directory by default (#703, @dmurdoch).
 * `commented_code_linter()` uses the parse tree to find comments, eliminating some false positives (#451, @AshesITR)
-* `trailing_blank_lines_linter()` now also lints if a trailing blank line is missing (#675, @AshesITR)
+* `trailing_blank_lines_linter()` now also lints files without a terminal newline (#675, @AshesITR)
 
 # lintr 2.0.1
 

--- a/R/exclude.R
+++ b/R/exclude.R
@@ -71,7 +71,15 @@ parse_exclusions <- function(file, exclude = settings$exclude,
                              exclude_end = settings$exclude_end,
                              exclude_linter = settings$exclude_linter,
                              exclude_linter_sep = settings$exclude_linter_sep) {
-  lines <- readLines(file)
+  lines <- withCallingHandlers({
+      readLines(file)
+    },
+    warning = function(w) {
+      if (grepl("incomplete final line found on", w$message, fixed = TRUE)) {
+        invokeRestart("muffleWarning")
+      }
+    }
+  )
 
   exclusions <- list()
 

--- a/R/trailing_blank_lines_linter.R
+++ b/R/trailing_blank_lines_linter.R
@@ -21,5 +21,19 @@ trailing_blank_lines_linter <- function(source_file) {
     }
     line_number <- line_number - 1L
   }
+  if (identical(source_file$terminal_newline, FALSE)) { # could use isFALSE, but needs backports
+    last_line <- tail(source_file$file_lines, 1L)
+
+    lints[[length(lints) + 1L]] <-
+      Lint(
+        filename = source_file$filename,
+        line_number = length(source_file$file_lines),
+        column_number = nchar(last_line) + 1L,
+        type = "style",
+        message = "Missing terminal newline.",
+        line = last_line,
+        linter = "trailing_blank_lines_linter"
+      )
+  }
   lints
 }

--- a/tests/testthat/test-trailing_blank_lines_linter.R
+++ b/tests/testthat/test-trailing_blank_lines_linter.R
@@ -1,46 +1,38 @@
 test_that("returns the correct linting", {
-  expect_lint("blah",
-    NULL,
-    trailing_blank_lines_linter)
+  linter <- trailing_blank_lines_linter
+  msg <- rex("Trailing blank lines are superfluous.")
+  msg2 <- rex("Missing terminal newline.")
 
-  expect_lint("blah <- 1  ",
-    NULL,
-    trailing_blank_lines_linter)
+  expect_lint("blah", NULL, linter)
+  expect_lint("blah <- 1  ", NULL, linter)
+  expect_lint("blah <- 1\nblah", NULL, linter)
+  expect_lint("blah <- 1\nblah\n \n blah", NULL, linter)
 
-  expect_lint("blah <- 1\nblah",
-    NULL,
-    trailing_blank_lines_linter)
+  expect_lint("blah <- 1\n", msg, linter)
+  expect_lint("blah <- 1\n  ", msg, linter)
 
-  expect_lint("blah <- 1\nblah\n \n blah",
-    NULL,
-    trailing_blank_lines_linter)
+  expect_lint("blah <- 1\n \n ", list(msg, msg), linter)
+  expect_lint("blah <- 1\n\n", list(msg, msg), linter)
+  expect_lint("blah <- 1\n\t\n", list(msg, msg), linter)
 
-  expect_lint("blah <- 1\n",
-    rex("Trailing blank lines are superfluous."),
-    trailing_blank_lines_linter)
+  # Construct a test file without terminal newline
+  # cf. test-get_source_expressions.R
+  writeLines("lm(y ~ x)", tmp <- tempfile())
+  on.exit(unlink(tmp), add = TRUE)
+  writeBin(
+    # strip the last (two) element(s) (\r\n or \n)
+    head(
+      readBin(tmp, raw(), file.size(tmp)),
+      if (.Platform$OS.type == "windows") -2L else -1L
+    ),
+    tmp2 <- tempfile()
+  )
+  on.exit(unlink(tmp2), add = TRUE)
 
-  expect_lint("blah <- 1\n  ",
-    rex("Trailing blank lines are superfluous."),
-    trailing_blank_lines_linter)
-
-  expect_lint("blah <- 1\n \n ",
-    list(
-      rex("Trailing blank lines are superfluous."),
-      rex("Trailing blank lines are superfluous.")
-      ),
-    trailing_blank_lines_linter)
-
-  expect_lint("blah <- 1\n\n",
-    list(
-      rex("Trailing blank lines are superfluous."),
-      rex("Trailing blank lines are superfluous.")
-      ),
-    trailing_blank_lines_linter)
-
-  expect_lint("blah <- 1\n\t\n",
-    list(
-      rex("Trailing blank lines are superfluous."),
-      rex("Trailing blank lines are superfluous.")
-      ),
-    trailing_blank_lines_linter)
+  expect_lint(content = NULL, file = tmp, NULL, linter)
+  expect_lint(content = NULL, file = tmp2, list(
+    message = msg2,
+    line_number = 1L,
+    column_number = 10L
+  ), linter)
 })


### PR DESCRIPTION
I had to fix `parse_exclusions()` as well because the `readLines()` used there didn't muffle the incomplete final line lint.

fixes #675

 - [x] implement
 - [x] test
 - [x] write NEWS bullet