### PR TITLE
fix warnings in test-dir_linters.R

### DIFF
--- a/tests/testthat/test-dir_linters.R
+++ b/tests/testthat/test-dir_linters.R
@@ -29,7 +29,7 @@ test_that("lint all relevant directories in a package", {
   # Code coverage is not detected for default_linters.
   # We want to ensure that object_name_linter uses namespace_imports correctly.
   # assignment_linter is needed to cause a lint in all vignettes.
-  linters <- list(assignment_linter, object_name_linter())
+  linters <- list(assignment_linter(), object_name_linter())
   read_settings(NULL)
   lints <- lint_package(the_pkg, linters = linters, parse_settings = FALSE)
   linted_files <- unique(names(lints))


### PR DESCRIPTION
Fixed warnings that were produced when running test-dir_linters.
These stemmed from using `assignment_linter` rather than
`assignment_linter()`.