### PR TITLE
Reduce cyclocomp of lint function

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,6 @@
 linters: with_defaults( # The following TODOs are part of an effort to have {lintr} lint-free (#584)
    line_length_linter = line_length_linter(120),
-   cyclocomp_linter = cyclocomp_linter(23) # TODO: reduce to 15
+   cyclocomp_linter = cyclocomp_linter(20) # TODO: reduce to 15
  )
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,

--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,6 @@
 linters: with_defaults( # The following TODOs are part of an effort to have {lintr} lint-free (#584)
    line_length_linter = line_length_linter(120),
-   cyclocomp_linter = cyclocomp_linter(28) # TODO reduce to 15
+   cyclocomp_linter = cyclocomp_linter(15)
  )
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,

--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,6 @@
 linters: with_defaults( # The following TODOs are part of an effort to have {lintr} lint-free (#584)
    line_length_linter = line_length_linter(120),
-   cyclocomp_linter = cyclocomp_linter(15)
+   cyclocomp_linter = cyclocomp_linter(23) # TODO: reduce to 15
  )
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,

--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,6 @@
 linters: with_defaults( # The following TODOs are part of an effort to have {lintr} lint-free (#584)
    line_length_linter = line_length_linter(120),
-   cyclocomp_linter = cyclocomp_linter(20) # TODO: reduce to 15
+   cyclocomp_linter = cyclocomp_linter(19) # TODO: reduce to 15
  )
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,

--- a/R/lint.R
+++ b/R/lint.R
@@ -74,20 +74,19 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
 
   for (expr in source_expressions$expressions) {
     for (linter in names(linters)) {
-      if (isTRUE(cache) && has_lint(lint_cache, expr, linter)) {
-        lints[[itr <- itr + 1L]] <- retrieve_lint(lint_cache, expr, linter, source_expressions$lines)
+      lint_details <- list(expr = expr, linter = linter)
+      should_retrieve <- isTRUE(cache) && has_lint(lint_cache, expr, linter)
+      if (should_retrieve) {
+        lint_details$expr_lints <- retrieve_lint(lint_cache, expr, linter, source_expressions$lines)
       }
       else {
-        expr_lints <- set_linter_name(
+        lint_details$expr_lints <- set_linter_name(
           flatten_lints(linters[[linter]](expr)),
           linter = linter
         )
-        lint_details <- list(
-          expr = expr, linter = linter, expr_lints = expr_lints
-        )
-        lints[[itr <- itr + 1L]] <- expr_lints
         cacheable <- append(cacheable, list(lint_details))
       }
+      lints[[itr <- itr + 1L]] <- lint_details[["expr_lints"]]
     }
   }
 


### PR DESCRIPTION
Ref https://github.com/jimhester/lintr/issues/653

Splits lint() function up; cyclomatic complexity of the resulting functions < 15.

This is work-in-progress. I have to check that the memory footprint and the cacheing are unaffected by the changes.