### PR TITLE
use correct index for rows of `code_candidates`

### DIFF
--- a/R/comment_linters.R
+++ b/R/comment_linters.R
@@ -57,13 +57,13 @@ commented_code_linter <- function() {
         Lint(
           filename = source_file$filename,
           line_number = line_number,
-          column_number = column_offset + code_candidates[line_number, "code.start"],
+          column_number = column_offset + code_candidates[code_candidate, "code.start"],
           type = "style",
           message = "Commented code should be removed.",
           line = source_file$file_lines[line_number],
           linter = "commented_code_linter",
-          ranges = list(column_offset + c(code_candidates[line_number, "code.start"],
-                                          code_candidates[line_number, "code.end"]))
+          ranges = list(column_offset + c(code_candidates[code_candidate, "code.start"],
+                                          code_candidates[code_candidate, "code.end"]))
         )
       }
     })

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -10,19 +10,32 @@ test_that("returns the correct linting", {
   expect_lint(
     "bleurgh <- fun_call(1) # other_call()",
     list(message = msg, column_number = 26),
-    linter)
+    linter
+  )
 
   expect_lint(
     " #blah <- 1",
     list(message = msg, column_number = 3),
-    linter)
+    linter
+  )
+
+  expect_lint(
+    trim_some("
+    # non-code comment
+    line_without_comment <- 42L
+     #blah <- 1
+    "),
+    list(message = msg, line_number = 3L, column_number = 3L),
+    linter
+  )
 
   expect_lint("#' blah <- 1", NULL, linter)
 
   expect_lint(
     c("a <- 1", "# comment without code"),
     NULL,
-    linter)
+    linter
+  )
 
   expect_lint(
     c("a <- 1", "# comment without code"),

--- a/tests/testthat/test-commented_code_linter.R
+++ b/tests/testthat/test-commented_code_linter.R
@@ -19,6 +19,7 @@ test_that("returns the correct linting", {
     linter
   )
 
+  # Regression test for #742, line number and comment number don't match up
   expect_lint(
     trim_some("
     # non-code comment


### PR DESCRIPTION
fixes #742

the XPath based code_candidates have one row per comment node, not one row per line