### PR TITLE
add name attribute to Linter class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,7 +37,8 @@
 * `paren_brace_linter` now marks lints at the opening brace instead of the closing parenthesis, making fixing the lints
   by jumping to source markers easier (#583, @AshesITR)
 * Lints are now marked with the name of the `linter` that caused them instead of the name of their implementation
-  function (#664, #673, @AshesITR).
+  function.    
+  Deprecated the obsolete `linter` argument of `Lint()`. (#664, #673, #746, @AshesITR)
 * New syntax to exclude only selected linters from linting lines or passages. Use `# nolint: linter_name, linter2_name.`
   or `# nolint start: linter_name, linter2_name.` in source files or named lists of line numbers in `.lintr`.
   (#660, @AshesITR)

--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -21,8 +21,7 @@ T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
             type = "style",
             message = sprintf("Use %s instead of the symbol %s.", replacement, symbol),
             line = source_file[["lines"]][[as.character(line_num)]],
-            ranges = list(c(start_col_num, end_col_num)),
-            linter = "T_and_F_symbol_linter"
+            ranges = list(c(start_col_num, end_col_num))
           )
         }
       }

--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -2,7 +2,8 @@
 #' @export
 assignment_linter <- function() {
   Linter(function(source_file) {
-    lapply(ids_with_token(source_file, "EQ_ASSIGN"),
+    lapply(
+      ids_with_token(source_file, "EQ_ASSIGN"),
       function(id) {
         parsed <- with_id(source_file, id)
         Lint(
@@ -11,9 +12,8 @@ assignment_linter <- function() {
           column_number = parsed$col1,
           type = "style",
           message = "Use <-, not =, for assignment.",
-          line = source_file$lines[as.character(parsed$line1)],
-          linter = "assignment_linter"
-          )
+          line = source_file$lines[as.character(parsed$line1)]
+        )
       })
-    })
+  })
 }

--- a/R/assignment_spaces_linter.R
+++ b/R/assignment_spaces_linter.R
@@ -24,8 +24,7 @@ assignment_spaces <- function() {
             column_number = parsed$col1,
             type = "style",
             message = "Assignments should only have one space before and after the operator.",
-            line = source_file$lines[parsed$line1],
-            linter = "assignment_spaces"
+            line = source_file$lines[parsed$line1]
           )
         }
       }

--- a/R/backport_linter.R
+++ b/R/backport_linter.R
@@ -40,8 +40,7 @@ backport_linter <- function(r_version = getRversion()) {
           all_names[ii], names(needs_backport_names)[which(needs_backport[ii, ])], r_version
         ),
         line = source_file$lines[[line1]],
-        ranges = list(c(col1, col2)),
-        linter = "backport_linter"
+        ranges = list(c(col1, col2))
       )
     })
   })

--- a/R/closed_curly_linter.R
+++ b/R/closed_curly_linter.R
@@ -58,8 +58,7 @@ closed_curly_linter <- function(allow_single_line = FALSE) {
               "Closing curly-braces should always be on their own line,",
               "unless they are followed by an else."
             ),
-            line = source_file$lines[as.character(parsed$line1)],
-            linter = "closed_curly_linter"
+            line = source_file$lines[as.character(parsed$line1)]
           )}
       }
     )

--- a/R/commas_linter.R
+++ b/R/commas_linter.R
@@ -59,17 +59,15 @@ commas_linter <- function() {
               !empty_comma &&
               !is_blank_switch) {
 
-              lints[[length(lints) + 1L]] <-
-                Lint(
-                  filename = source_file$filename,
-                  line_number = line_number,
-                  column_number = comma_loc,
-                  type = "style",
-                  message = "Commas should never have a space before.",
-                  line = line,
-                  ranges = list(c(start, end)),
-                  "commas_linter"
-                )
+              lints[[length(lints) + 1L]] <- Lint(
+                filename = source_file$filename,
+                line_number = line_number,
+                column_number = comma_loc,
+                type = "style",
+                message = "Commas should never have a space before.",
+                line = line,
+                ranges = list(c(start, end))
+              )
             }
           }
 
@@ -83,17 +81,14 @@ commas_linter <- function() {
                                source_file$parsed_content$token == "','")
 
             if (has_token) {
-
-              lints[[length(lints) + 1L]] <-
-                Lint(
-                  filename = source_file$filename,
-                  line_number = line_number,
-                  column_number = comma_loc + 1,
-                  type = "style",
-                  message = "Commas should always have a space after.",
-                  line = line,
-                  linter = "commas_linter"
-                )
+              lints[[length(lints) + 1L]] <- Lint(
+                filename = source_file$filename,
+                line_number = line_number,
+                column_number = comma_loc + 1,
+                type = "style",
+                message = "Commas should always have a space after.",
+                line = line
+              )
             }
 
           }

--- a/R/comment_linters.R
+++ b/R/comment_linters.R
@@ -61,7 +61,6 @@ commented_code_linter <- function() {
           type = "style",
           message = "Commented code should be removed.",
           line = source_file$file_lines[line_number],
-          linter = "commented_code_linter",
           ranges = list(column_offset + c(code_candidates[code_candidate, "code.start"],
                                           code_candidates[code_candidate, "code.end"]))
         )
@@ -95,8 +94,7 @@ todo_comment_linter <- function(todo = c("todo", "fixme")) {
           type = "style",
           message = "TODO comments should be removed.",
           line = source_file[["lines"]][[as.character(token[["line1"]])]],
-          ranges = list(c(token[["col1"]], token[["col2"]])),
-          linter = "todo_comment_linter"
+          ranges = list(c(token[["col1"]], token[["col2"]]))
         )
       }
     )

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -25,8 +25,7 @@ cyclocomp_linter <- function(complexity_limit = 15L) {
         complexity_limit, ", this has ", complexity, "."
       ),
       ranges = list(c(source_file[["column"]][1], source_file[["column"]][1])),
-      line = source_file$lines[1],
-      linter = "cyclocomp_linter"
+      line = source_file$lines[1]
     )
   })
 }

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -61,8 +61,7 @@ camel_case_linter <- make_object_linter(function(source_file, parsed) {
       !is_base_function(parsed$text)) {
     object_lint(source_file,
                 parsed,
-                "Variable and function names should be all lowercase.",
-                "camel_case_linter")
+                "Variable and function names should be all lowercase.")
   }
 }, name = "camel_case_linter")
 
@@ -80,8 +79,7 @@ snake_case_linter <- make_object_linter(function(source_file, parsed) {
       !is_base_function(parsed$text)) {
     object_lint(source_file,
                 parsed,
-                "Variable and function names should not use underscores.",
-                "snake_case_linter")
+                "Variable and function names should not use underscores.")
   }
 }, name = "snake_case_linter")
 
@@ -98,7 +96,6 @@ multiple_dots_linter <- make_object_linter(function(source_file, parsed) {
       !is_base_function(parsed$text)) {
     object_lint(source_file,
                 parsed,
-                "Words within variable and function names should be separated by '_' rather than '.'.",
-                "multiple_dots_linter")
+                "Words within variable and function names should be separated by '_' rather than '.'.")
   }
 }, name = "multiple_dots_linter")

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -62,7 +62,7 @@ camel_case_linter <- make_object_linter(function(source_file, parsed) {
                 "Variable and function names should be all lowercase.",
                 "camel_case_linter")
   }
-})
+}, name = "camel_case_linter")
 
 
 #' @describeIn lintr-deprecated Check that objects are not in snake_case.
@@ -81,7 +81,7 @@ snake_case_linter <- make_object_linter(function(source_file, parsed) {
                 "Variable and function names should not use underscores.",
                 "snake_case_linter")
   }
-})
+}, name = "snake_case_linter")
 
 
 #' @describeIn lintr-deprecated check that objects do not have.multiple.dots.
@@ -99,4 +99,4 @@ multiple_dots_linter <- make_object_linter(function(source_file, parsed) {
                 "Words within variable and function names should be separated by '_' rather than '.'.",
                 "multiple_dots_linter")
   }
-})
+}, name = "multiple_dots_linter")

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -35,6 +35,7 @@ absolute_paths_linter <- function(source_file) {
   absolute_path_linter(lax = TRUE)(source_file)
 }
 class(absolute_paths_linter) <- "linter"
+attr(absolute_paths_linter, "name") <- "absolute_paths_linter"
 
 
 #' @describeIn lintr-deprecated Check there are no trailing semicolons.
@@ -44,6 +45,7 @@ trailing_semicolons_linter <- function(source_file) {
   semicolon_terminator_linter(semicolon = "trailing")(source_file)
 }
 class(trailing_semicolons_linter) <- "linter"
+attr(trailing_semicolons_linter, "name") <- "trailing_semicolons_linter"
 
 
 #' @describeIn lintr-deprecated Check that objects are not in camelCase.

--- a/R/equals_na_linter.R
+++ b/R/equals_na_linter.R
@@ -19,6 +19,6 @@ equals_na_linter <- function() {
 
     lapply(bad_expr, xml_nodes_to_lint, source_file,
            message = "Use is.na for comparisons to NA (not == or !=)",
-           linter = "equals_na_linter", type = "warning")
+           type = "warning")
   })
 }

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -70,8 +70,9 @@ expect_lint <- function(content, checks, ..., file = NULL, language = "en") {
   }
 
   local({
-    itr <- 0L #nolint
-    lint_fields <- names(formals(Lint))
+    itr <- 0L
+    # keep 'linter' as a field even if we remove the deprecated argument from Lint() in the future
+    lint_fields <- unique(c(names(formals(Lint)), "linter"))
     Map(function(lint, check) {
       itr <<- itr + 1L
       lapply(names(check), function(field) {

--- a/R/extraction_operator_linter.R
+++ b/R/extraction_operator_linter.R
@@ -3,8 +3,8 @@
 #' @export
 extraction_operator_linter <- function() {
   Linter(function(source_file) {
-    tokens <- source_file[["parsed_content"]] <-
-      filter_out_token_type(source_file[["parsed_content"]], "expr")
+    tokens <- source_file[["parsed_content"]] <- filter_out_token_type(source_file[["parsed_content"]], "expr")
+
     lapply(
       ids_with_token(source_file, c("'$'", "'['"), fun = `%in%`),
       function(token_num) {
@@ -14,6 +14,7 @@ extraction_operator_linter <- function() {
           end_col_num <- token[["col2"]]
           line_num <- token[["line1"]]
           line <- source_file[["lines"]][[as.character(line_num)]]
+
           Lint(
             filename = source_file[["filename"]],
             line_number = line_num,
@@ -21,7 +22,6 @@ extraction_operator_linter <- function() {
             type = "warning",
             message = sprintf("Use `[[` instead of `%s`  to extract an element.", token[["text"]]),
             line = line,
-            linter = "extraction_operator_linter",
             ranges = list(c(start_col_num, end_col_num))
           )
         }

--- a/R/function_left_parentheses.R
+++ b/R/function_left_parentheses.R
@@ -7,7 +7,7 @@ function_left_parentheses_linter <- function() { # nolint: object_length_linter.
       ids_with_token(source_file, "'('"),
       function(id) {
 
-        parsed <- source_file$parsed_content[id,]
+        parsed <- source_file$parsed_content[id, ]
 
         terminal_tokens_before <-
           source_file$parsed_content$line1 == parsed$line1 &

--- a/R/function_left_parentheses.R
+++ b/R/function_left_parentheses.R
@@ -7,7 +7,7 @@ function_left_parentheses_linter <- function() { # nolint: object_length_linter.
       ids_with_token(source_file, "'('"),
       function(id) {
 
-        parsed <- source_file$parsed_content[id, ]
+        parsed <- source_file$parsed_content[id,]
 
         terminal_tokens_before <-
           source_file$parsed_content$line1 == parsed$line1 &
@@ -34,12 +34,11 @@ function_left_parentheses_linter <- function() { # nolint: object_length_linter.
               column_number = parsed$col1,
               type = "style",
               message = "Remove spaces before the left parenthesis in a function call.",
-              line = line,
-              linter = "function_left_parentheses_linter"
+              line = line
             )
           }
         }
-
-      })
+      }
+    )
   })
 }

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -106,8 +106,7 @@ get_source_expressions <- function(filename) {
               column_number = 1,
               type = "error",
               message = e$message,
-              line = "",
-              linter = "error"
+              line = ""
             )
           )
           # nocov end
@@ -123,8 +122,7 @@ get_source_expressions <- function(filename) {
           column_number = column_number,
           type = "error",
           message = e$message,
-          line = source_file$lines[[line_number]],
-          linter = "error"
+          line = source_file$lines[[line_number]]
         )
       )
     }
@@ -148,8 +146,7 @@ get_source_expressions <- function(filename) {
       column_number = column_number,
       type = "error",
       message = message_info$message,
-      line = line,
-      linter = "error"
+      line = line
     )
   }
 
@@ -178,8 +175,7 @@ get_source_expressions <- function(filename) {
       column_number = column_number,
       type = "error",
       message = message_info$message,
-      line = source_file$lines[line_number],
-      linter = "error"
+      line = source_file$lines[line_number]
     )
   }
 

--- a/R/implicit_integer_linter.R
+++ b/R/implicit_integer_linter.R
@@ -19,8 +19,7 @@ implicit_integer_linter <- function() {
             message =
               "Integers should not be implicit. Use the form 1L for integers or 1.0 for doubles.",
             line = source_file[["lines"]][[as.character(line_num)]],
-            ranges = list(c(start_col_num, end_col_num)),
-            linter = "implicit_integer_linter"
+            ranges = list(c(start_col_num, end_col_num))
           )
         }
       }

--- a/R/infix_spaces_linter.R
+++ b/R/infix_spaces_linter.R
@@ -21,32 +21,29 @@ infix_tokens <- c(
   "'*'",          # *        : unary multiplication
 
   NULL
-  )
+)
 
 #' @describeIn linters  Check that infix operators are surrounded by spaces.
 #' @export
 infix_spaces_linter <- function() {
   Linter(function(source_file) {
-    lapply(ids_with_token(source_file, infix_tokens, fun = `%in%`),
+    lapply(
+      ids_with_token(source_file, infix_tokens, fun = `%in%`),
       function(id) {
         parsed <- with_id(source_file, id)
 
         line <- source_file$lines[as.character(parsed$line1)]
 
         around_operator <- substr(line, parsed$col1 - 1L, parsed$col2 + 1L)
-
         non_space_before <- re_matches(around_operator, rex(start, non_space))
-
         newline_after <- unname(nchar(line)) %==% parsed$col2
-
         non_space_after <- re_matches(around_operator, rex(non_space, end))
 
         if (non_space_before || (!newline_after && non_space_after)) {
 
           # we only should check spacing if the operator is infix,
           # which only happens if there is more than one sibling
-          is_infix <-
-            length(siblings(source_file$parsed_content, parsed$id, 1)) > 1L
+          is_infix <- length(siblings(source_file$parsed_content, parsed$id, 1)) > 1L
 
           start <- end <- parsed$col1
 
@@ -65,13 +62,10 @@ infix_spaces_linter <- function() {
               type = "style",
               message = "Put spaces around all infix operators.",
               line = line,
-              ranges = list(c(start, end)),
-              linter = "infix_spaces_linter"
-              )
-
+              ranges = list(c(start, end))
+            )
           }
         }
-
       })
   })
 }

--- a/R/line_length_linter.R
+++ b/R/line_length_linter.R
@@ -20,8 +20,7 @@ line_length_linter <- function(length = 80L) {
         type = "style",
         message = lint_message,
         line = source_file$file_lines[long_line],
-        ranges = list(c(1L, line_lengths[long_line])),
-        linter = "line_length_linter"
+        ranges = list(c(1L, line_lengths[long_line]))
       )
     })
   })

--- a/R/lint.R
+++ b/R/lint.R
@@ -278,7 +278,6 @@ lint_package <- function(path = ".", relative_path = TRUE, ...,
   lints
 }
 
-
 define_linters <- function(linters = NULL) {
   if (is.null(linters)) {
     linters <- settings$linters

--- a/R/lint.R
+++ b/R/lint.R
@@ -55,6 +55,9 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
   if (is.null(linters)) {
     linters <- settings$linters
     names(linters) <- auto_names(linters)
+  } else if (inherits(linters, "linter")) {
+    linters <- list(linters)
+    names(linters) <- attr(linters[[1L]], "name", exact = TRUE)
   } else if (!is.list(linters)) {
     name <- deparse(substitute(linters))
     linters <- list(linters)
@@ -78,7 +81,7 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
           new <- "linters classed as 'linter' (see ?Linter)"
           lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
                            type = "")
-          obj <- Linter(obj)
+          obj <- Linter(obj, name = name)
         }
       } else {
         stop(gettextf("Expected '%s' to be of class 'linter', not '%s'",

--- a/R/lint.R
+++ b/R/lint.R
@@ -383,12 +383,19 @@ pkg_name <- function(path = find_package()) {
 #' @param message message used to describe the lint error
 #' @param line code source where the lint occurred
 #' @param ranges a list of ranges on the line that should be emphasized.
-#' @param linter name of linter that created the Lint object.
+#' @param linter deprecated. No longer used.
 #' @return an object of class 'lint'.
 #' @export
 Lint <- function(filename, line_number = 1L, column_number = 1L, # nolint: object_name_linter.
                  type = c("style", "warning", "error"),
                  message = "", line = "", ranges = NULL, linter = "") {
+  if (!missing(linter)) {
+    lintr_deprecated(
+      old = "Using the `linter` argument of `Lint()`",
+      version = "2.0.1.9001",
+      type = ""
+    )
+  }
 
   type <- match.arg(type)
 
@@ -401,7 +408,7 @@ Lint <- function(filename, line_number = 1L, column_number = 1L, # nolint: objec
       message = message,
       line = line,
       ranges = ranges,
-      linter = linter
+      linter = NA_character_
     ),
     class = "lint")
 }

--- a/R/make_linter_from_regex.R
+++ b/R/make_linter_from_regex.R
@@ -1,5 +1,4 @@
 make_linter_from_regex <- function(regex,
-                                   lint_name,
                                    lint_type,
                                    lint_msg,
                                    ignore_strings = TRUE) {
@@ -39,8 +38,7 @@ make_linter_from_regex <- function(regex,
                 type = lint_type,
                 message = lint_msg,
                 line = source_file[["lines"]][[as.character(line_number)]],
-                ranges = list(c(start, end)),
-                linter = lint_name
+                ranges = list(c(start, end))
               )
             }
           )

--- a/R/missing_argument_linter.R
+++ b/R/missing_argument_linter.R
@@ -32,8 +32,7 @@ missing_argument_linter <- function(except = c("switch", "alist")) {
           type = "warning",
           message = "Missing argument in function call.",
           line = source_file$file_lines[line1[[i]]],
-          ranges = list(c(col1[[i]], col2[[i]])),
-          linter = "missing_argument_linter"
+          ranges = list(c(col1[[i]], col2[[i]]))
         )
       }
     })

--- a/R/missing_package_linter.R
+++ b/R/missing_package_linter.R
@@ -38,8 +38,7 @@ missing_package_linter <- function() {
         type = "warning",
         message = sprintf("Package '%s' is not installed.", pkg_names[[i]]),
         line = source_file$file_lines[line1[[i]]],
-        ranges = list(c(col1[[i]], col2[[i]])),
-        linter = "missing_package_linter"
+        ranges = list(c(col1[[i]], col2[[i]]))
       )
     })
   })

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -48,8 +48,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
                   type = "warning",
                   message = sprintf("'%s' is not exported from {%s}.", syms[[i]], pkgs[[i]]),
                   line = source_file$file_lines[line1],
-                  ranges = list(c(col1, col2)),
-                  linter = "namespace_linter"
+                  ranges = list(c(col1, col2))
                 ))
               }
             }
@@ -69,8 +68,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
                     message = sprintf("'%s' is exported from {%s}. Use %s::%s instead.",
                       syms[[i]], pkgs[[i]], pkgs[[i]], syms[[i]]),
                     line = source_file$file_lines[line1],
-                    ranges = list(c(col1, col2)),
-                    linter = "namespace_linter"
+                    ranges = list(c(col1, col2))
                   ))
                 }
               } else {
@@ -84,8 +82,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
                   type = "warning",
                   message = sprintf("'%s' does not exist in {%s}.", syms[[i]], pkgs[[i]]),
                   line = source_file$file_lines[line1],
-                  ranges = list(c(col1, col2)),
-                  linter = "namespace_linter"
+                  ranges = list(c(col1, col2))
                 ))
               }
             }
@@ -101,8 +98,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
               type = "warning",
               message = conditionMessage(ns),
               line = source_file$file_lines[line1],
-              ranges = list(c(col1, col2)),
-              linter = "namespace_linter"
+              ranges = list(c(col1, col2))
             ))
             # nocov end
           }
@@ -118,8 +114,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
           type = "warning",
           message = sprintf("Package '%s' is not installed.", pkgs[[i]]),
           line = source_file$file_lines[line1],
-          ranges = list(c(col1, col2)),
-          linter = "namespace_linter"
+          ranges = list(c(col1, col2))
         ))
       }
     })

--- a/R/no_tab_linter.R
+++ b/R/no_tab_linter.R
@@ -4,7 +4,6 @@
 #' @export
 no_tab_linter <- make_linter_from_regex(
   regex = rex(start, zero_or_more(regex("\\s")), one_or_more("\t")),
-  lint_name = "no_tab_linter",
   lint_type = "style",
   lint_msg = "Use spaces to indent, not tabs."
 )

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -68,8 +68,7 @@ object_name_linter <- function(styles = c("snake_case", "symbols")) {
       assignments[!matches_a_style],
       object_lint2,
       source_file,
-      lint_msg,
-      "object_name_linter"
+      lint_msg
     )
   })
 }
@@ -105,7 +104,7 @@ strip_names <- function(x) {
   x
 }
 
-object_lint2 <- function(expr, source_file, message, type) {
+object_lint2 <- function(expr, source_file, message) {
   symbol <- xml2::as_list(expr)
   Lint(
     filename = source_file$filename,
@@ -115,8 +114,7 @@ object_lint2 <- function(expr, source_file, message, type) {
     message = message,
     line = source_file$file_lines[as.numeric(symbol@line1)],
     ranges = list(as.numeric(c(symbol@col1, symbol@col2))),
-    linter = type
-    )
+  )
 }
 
 make_object_linter <- function(fun, name = linter_auto_name()) {
@@ -267,7 +265,7 @@ is_special_function <- function(x) {
   x %in% special_funs
 }
 
-object_lint <- function(source_file, token, message, type) {
+object_lint <- function(source_file, token, message) {
   Lint(
     filename = source_file$filename,
     line_number = token$line1,
@@ -275,8 +273,7 @@ object_lint <- function(source_file, token, message, type) {
     type = "style",
     message = message,
     line = source_file$lines[as.character(token$line1)],
-    ranges = list(c(token$col1, token$col2)),
-    linter = type
+    ranges = list(c(token$col1, token$col2))
   )
 }
 
@@ -305,8 +302,7 @@ object_length_linter <- function(length = 30L) {
         object_lint(
           source_file,
           token,
-          paste0("Variable and function names should not be longer than ", length, " characters."),
-          "object_length_linter"
+          paste0("Variable and function names should not be longer than ", length, " characters.")
         )
       }
   })

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -119,7 +119,8 @@ object_lint2 <- function(expr, source_file, message, type) {
     )
 }
 
-make_object_linter <- function(fun) {
+make_object_linter <- function(fun, name = linter_auto_name()) {
+  force(name)
   Linter(function(source_file) {
 
     token_nums <- ids_with_token(
@@ -147,7 +148,7 @@ make_object_linter <- function(fun) {
         }
       }
     )
-  })
+  }, name = name)
 }
 
 known_generic_regex <- rex(

--- a/R/object_usage_linter.R
+++ b/R/object_usage_linter.R
@@ -70,8 +70,7 @@ object_usage_linter <- function() {
                  type = "warning",
                  message = row$message,
                  line = line,
-                 ranges = list(c(location$start, location$end)),
-                 linter = "object_usage_linter"
+                 ranges = list(c(location$start, location$end))
                )
              })
     })

--- a/R/open_curly_linter.R
+++ b/R/open_curly_linter.R
@@ -3,61 +3,63 @@
 #' @export
 open_curly_linter <- function(allow_single_line = FALSE) {
   Linter(function(source_file) {
-    lapply(ids_with_token(source_file, "'{'"),
-           function(id) {
+    lapply(
+      ids_with_token(source_file, "'{'"),
+      function(id) {
 
-             parsed <- with_id(source_file, id)
+        parsed <- with_id(source_file, id)
 
-             tokens_before <- source_file$parsed_content$token[
-                                                               source_file$parsed_content$line1 == parsed$line1 &
-                                                               source_file$parsed_content$col1 < parsed$col1]
+        tokens_before <- source_file$parsed_content$token[
+          source_file$parsed_content$line1 == parsed$line1 &
+            source_file$parsed_content$col1 < parsed$col1]
 
-             tokens_after <- source_file$parsed_content$token[
-                                                              source_file$parsed_content$line1 == parsed$line1 &
-                                                              source_file$parsed_content$col1 > parsed$col1 &
-                                                              source_file$parsed_content$token != "COMMENT"]
+        tokens_after <- source_file$parsed_content$token[
+          source_file$parsed_content$line1 == parsed$line1 &
+            source_file$parsed_content$col1 > parsed$col1 &
+            source_file$parsed_content$token != "COMMENT"]
 
-             if (isTRUE(allow_single_line) &&
-                 "'}'" %in% tokens_after) {
-               return()
-             }
+        if (isTRUE(allow_single_line) &&
+            "'}'" %in% tokens_after) {
+          return()
+        }
 
-             line <- source_file$lines[as.character(parsed$line1)]
+        line <- source_file$lines[as.character(parsed$line1)]
 
-             # the only tokens should be the { and the start of the expression.
-             some_before <- length(tokens_before) %!=% 0L
-             some_after <- length(tokens_after) %!=% 0L
+        # the only tokens should be the { and the start of the expression.
+        some_before <- length(tokens_before) %!=% 0L
+        some_after <- length(tokens_after) %!=% 0L
 
-             content_after <- unname(substr(line, parsed$col1 + 1L, nchar(line)))
-             content_before <- unname(substr(line, 1, parsed$col1 - 1L))
+        content_after <- unname(substr(line, parsed$col1 + 1L, nchar(line)))
+        content_before <- unname(substr(line, 1, parsed$col1 - 1L))
 
-             only_comment <- rex::re_matches(content_after, rex::rex(any_spaces, "#", something, end))
+        only_comment <- rex::re_matches(content_after, rex::rex(any_spaces, "#", something, end))
 
-             double_curly <- rex::re_matches(content_after, rex::rex(start, "{")) ||
-               rex::re_matches(content_before, rex::rex("{", end))
+        double_curly <- rex::re_matches(content_after, rex::rex(start, "{")) ||
+          rex::re_matches(content_before, rex::rex("{", end))
 
-             if (double_curly) {
-               return()
-             }
+        if (double_curly) {
+          return()
+        }
 
-             whitespace_after <-
-               unname(substr(line, parsed$col1 + 1L, parsed$col1 + 1L)) %!=% ""
+        whitespace_after <-
+          unname(substr(line, parsed$col1 + 1L, parsed$col1 + 1L)) %!=% ""
 
-             if (!some_before || some_after || (whitespace_after && !only_comment)) {
-               Lint(
-                    filename = source_file$filename,
-                    line_number = parsed$line1,
-                    column_number = parsed$col1,
-                    type = "style",
-                    message = paste(
-                      "Opening curly braces should never go on their own line and",
-                      "should always be followed by a new line."
-                    ),
-                    line = line,
-                    linter = "open_curly_linter"
-                    )
-             }
-
-           })
+        if (!some_before ||
+          some_after ||
+          (whitespace_after && !only_comment)) {
+          Lint(
+            filename = source_file$filename,
+            line_number = parsed$line1,
+            column_number = parsed$col1,
+            type = "style",
+            message = paste(
+              "Opening curly braces should never go on their own line and",
+              "should always be followed by a new line."
+            ),
+            line = line
+          )
+        }
+      }
+    )
   })
 }

--- a/R/paren_brace_linter.R
+++ b/R/paren_brace_linter.R
@@ -34,8 +34,7 @@ paren_brace_linter <- function() {
           type = "style",
           message = "There should be a space between right parenthesis and an opening curly brace.",
           line = line,
-          ranges = list(as.numeric(c(x@col1, x@col2))),
-          "paren_brace_linter"
+          ranges = list(as.numeric(c(x@col1, x@col2)))
         )
       }
     )

--- a/R/path_linters.R
+++ b/R/path_linters.R
@@ -162,8 +162,7 @@ make_path_linter <- function(path_function, message, linter, name = linter_auto_
             type = "warning",
             message = message,
             line = source_file[["lines"]][[as.character(token[["line1"]])]],
-            ranges = list(c(start, end)),
-            linter = linter
+            ranges = list(c(start, end))
           )
         }
       }
@@ -179,8 +178,7 @@ absolute_path_linter <- function(lax = TRUE) {
     path_function = function(path) {
       is_absolute_path(path) && is_valid_long_path(path, lax)
     },
-    message = "Do not use absolute paths.",
-    linter = "absolute_path_linter"
+    message = "Do not use absolute paths."
   )
 }
 
@@ -192,7 +190,6 @@ nonportable_path_linter <- function(lax = TRUE) {
       is_path(path) && is_valid_long_path(path, lax) && path != "/" &&
         re_matches(path, rex(one_of("/", "\\")))
     },
-    message = "Use file.path() to construct portable file paths.",
-    linter = "nonportable_filepath_linter"
+    message = "Use file.path() to construct portable file paths."
   )
 }

--- a/R/path_linters.R
+++ b/R/path_linters.R
@@ -139,7 +139,8 @@ split_path <- function(path, sep="/|\\\\") {
 }
 
 #' @include utils.R
-make_path_linter <- function(path_function, message, linter) {
+make_path_linter <- function(path_function, message, linter, name = linter_auto_name()) {
+  force(name)
   Linter(function(source_file) {
     lapply(
       ids_with_token(source_file, "STR_CONST"),
@@ -167,7 +168,7 @@ make_path_linter <- function(path_function, message, linter) {
         }
       }
     )
-  })
+  }, name = name)
 }
 
 #' @describeIn linters  Check that no absolute paths are used (e.g. "/var", "C:\\System", "~/docs").

--- a/R/pipe_continuation_linter.R
+++ b/R/pipe_continuation_linter.R
@@ -67,8 +67,7 @@ pipe_continuation_linter <- function() {
             " unless the full pipeline fits on one line."
           ),
           line = line,
-          ranges = list(as.numeric(c(x@col1, x@col2))),
-          "pipe_continuation_linter"
+          ranges = list(as.numeric(c(x@col1, x@col2)))
         )
       })
   })

--- a/R/semicolon_terminator_linter.R
+++ b/R/semicolon_terminator_linter.R
@@ -22,6 +22,7 @@ semicolon_terminator_linter <- function(semicolon = c("compound", "trailing")) {
         } else  {
           "Compound semicolons are not needed. Replace them by a newline."
         }
+
         Lint(
           filename = source_file[["filename"]],
           line_number = token[["line1"]],
@@ -29,8 +30,7 @@ semicolon_terminator_linter <- function(semicolon = c("compound", "trailing")) {
           type = "style",
           message = msg,
           line = source_file[["lines"]][[as.character(token[["line1"]])]],
-          ranges = list(c(token[["col1"]], token[["col2"]])),
-          linter = "semicolon_linter"
+          ranges = list(c(token[["col1"]], token[["col2"]]))
         )
       },
       split(tokens, seq_len(nrow(tokens))),
@@ -38,7 +38,6 @@ semicolon_terminator_linter <- function(semicolon = c("compound", "trailing")) {
     )
   })
 }
-
 
 is_trailing_sc <- function(sc_tokens, source_file) {
   line_str <- source_file[["lines"]][as.character(sc_tokens[["line1"]])]

--- a/R/seq_linter.R
+++ b/R/seq_linter.R
@@ -50,8 +50,7 @@ seq_linter <- function() {
           message = paste0(f1, ":", f2, " is likely to be wrong in the empty ",
                            "edge case, use seq_len."),
           line = source_file$lines[line1],
-          ranges = list(c(as.integer(col1), as.integer(col2))),
-          linter = "seq_linter"
+          ranges = list(c(as.integer(col1), as.integer(col2)))
         )
       }
     )

--- a/R/single_quotes_linter.R
+++ b/R/single_quotes_linter.R
@@ -27,8 +27,7 @@ single_quotes_linter <- function() {
             type = "style",
             message = "Only use double-quotes.",
             line = line,
-            ranges = list(c(col1, col2)),
-            linter = "single_quotes_linter"
+            ranges = list(c(col1, col2))
           )
         })
       }

--- a/R/spaces_inside_linter.R
+++ b/R/spaces_inside_linter.R
@@ -47,8 +47,7 @@ spaces_inside_linter <- function() {
                   column_number = if (substr(line, start, start) == " ") start else start + 1L,
                   type = "style",
                   message = "Do not place spaces around code in parentheses or square brackets.",
-                  line = line,
-                  linter = "spaces_inside_linter"
+                  line = line
                 )
               }
             }

--- a/R/spaces_left_parentheses_linter.R
+++ b/R/spaces_left_parentheses_linter.R
@@ -53,8 +53,7 @@ spaces_left_parentheses_linter <- function() {
               column_number = parsed$col1,
               type = "style",
               message = "Place a space before left parenthesis, except in a function call.",
-              line = line,
-              linter = "spaces_left_parentheses_linter"
+              line = line
             )
           }
         }

--- a/R/sprintf_linter.R
+++ b/R/sprintf_linter.R
@@ -53,8 +53,7 @@ sprintf_linter <- function() {
             type = "warning",
             message = conditionMessage(res),
             line = source_file$file_lines[line1],
-            ranges = list(c(col1, col2)),
-            linter = "sprintf_linter"
+            ranges = list(c(col1, col2))
           )
         }
       }

--- a/R/trailing_blank_lines_linter.R
+++ b/R/trailing_blank_lines_linter.R
@@ -4,38 +4,34 @@
 trailing_blank_lines_linter <- function() {
   Linter(function(source_file) {
     blanks <- re_matches(source_file$file_lines,
-      rex(start, any_spaces, end))
+                         rex(start, any_spaces, end))
 
     line_number <- length(source_file$file_lines)
     lints <- list()
     while (line_number > 0L && (is.na(blanks[[line_number]]) || isTRUE(blanks[[line_number]]))) {
       if (!is.na(blanks[[line_number]])) {
-        lints[[length(lints) + 1L]] <-
-          Lint(
-            filename = source_file$filename,
-            line_number = line_number,
-            column_number = 1,
-            type = "style",
-            message = "Trailing blank lines are superfluous.",
-            line = source_file$file_lines[[line_number]],
-            linter = "trailing_blank_lines_linter"
-            )
+        lints[[length(lints) + 1L]] <- Lint(
+          filename = source_file$filename,
+          line_number = line_number,
+          column_number = 1,
+          type = "style",
+          message = "Trailing blank lines are superfluous.",
+          line = source_file$file_lines[[line_number]]
+        )
       }
       line_number <- line_number - 1L
     }
     if (identical(source_file$terminal_newline, FALSE)) { # could use isFALSE, but needs backports
       last_line <- tail(source_file$file_lines, 1L)
 
-      lints[[length(lints) + 1L]] <-
-        Lint(
-          filename = source_file$filename,
-          line_number = length(source_file$file_lines),
-          column_number = nchar(last_line) + 1L,
-          type = "style",
-          message = "Missing terminal newline.",
-          line = last_line,
-          linter = "trailing_blank_lines_linter"
-        )
+      lints[[length(lints) + 1L]] <- Lint(
+        filename = source_file$filename,
+        line_number = length(source_file$file_lines),
+        column_number = nchar(last_line) + 1L,
+        type = "style",
+        message = "Missing terminal newline.",
+        line = last_line
+      )
     }
     lints
   })

--- a/R/trailing_whitespace_linter.R
+++ b/R/trailing_whitespace_linter.R
@@ -3,34 +3,35 @@
 #' @export
 trailing_whitespace_linter <- function() {
   Linter(function(source_file) {
-    res <- re_matches(source_file$lines,
+    res <- re_matches(
+      source_file$lines,
       rex(capture(name = "space", some_of(" ", regex("\\t"))), or(newline, end)),
       global = TRUE,
-      locations = TRUE)
+      locations = TRUE
+    )
 
     lapply(seq_along(source_file$lines), function(itr) {
 
-        mapply(
-          FUN = function(start, end) {
-            if (is.na(start)) {
-              return()
-            }
-            line_number <- names(source_file$lines)[itr]
-            Lint(
-              filename = source_file$filename,
-              line_number = line_number,
-              column_number = start,
-              type = "style",
-              message = "Trailing whitespace is superfluous.",
-              line = source_file$lines[as.character(line_number)],
-              ranges = list(c(start, end)),
-              linter = "trailing_whitespace_linter"
-              )
-          },
-          start = res[[itr]]$space.start,
-          end = res[[itr]]$space.end,
-          SIMPLIFY = FALSE
+      mapply(
+        FUN = function(start, end) {
+          if (is.na(start)) {
+            return()
+          }
+          line_number <- names(source_file$lines)[itr]
+          Lint(
+            filename = source_file$filename,
+            line_number = line_number,
+            column_number = start,
+            type = "style",
+            message = "Trailing whitespace is superfluous.",
+            line = source_file$lines[as.character(line_number)],
+            ranges = list(c(start, end))
           )
+        },
+        start = res[[itr]]$space.start,
+        end = res[[itr]]$space.end,
+        SIMPLIFY = FALSE
+      )
     })
 
   })

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -29,6 +29,7 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
           if (!is.na(alt_fun)) {
             msg <- c(msg, sprintf("As an alternative, %s.", alt_fun))
           }
+
           Lint(
             filename = source_file[["filename"]],
             line_number = line_num,
@@ -36,8 +37,7 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
             type = "warning",
             message = paste0(msg, collapse = " "),
             line = source_file[["lines"]][[as.character(line_num)]],
-            ranges = list(c(start_col_num, end_col_num)),
-            linter = "undesirable_function_linter"
+            ranges = list(c(start_col_num, end_col_num))
           )
         }
       }

--- a/R/undesirable_operator_linter.R
+++ b/R/undesirable_operator_linter.R
@@ -29,6 +29,7 @@ undesirable_operator_linter <- function(op = default_undesirable_operators) {
           if (!is.na(alt_op)) {
             msg <- c(msg, sprintf("As an alternative, %s.", alt_op))
           }
+
           Lint(
             filename = source_file[["filename"]],
             line_number = line_num,
@@ -36,8 +37,7 @@ undesirable_operator_linter <- function(op = default_undesirable_operators) {
             type = "warning",
             message = paste0(msg, collapse = " "),
             line = source_file[["lines"]][[as.character(line_num)]],
-            ranges = list(c(start_col_num, end_col_num)),
-            linter = "undesirable_function_linter"
+            ranges = list(c(start_col_num, end_col_num))
           )
         }
       }

--- a/R/unneeded_concatenation_linter.R
+++ b/R/unneeded_concatenation_linter.R
@@ -24,7 +24,6 @@ unneeded_concatenation_linter <- function() {
             type = "warning",
             message = if (num_args) msg_const else msg_empty,
             line = line,
-            linter = "unneeded_concatenation_linter",
             ranges = list(c(start_col_num, end_col_num))
           )
         }

--- a/R/utils.R
+++ b/R/utils.R
@@ -200,7 +200,7 @@ unescape <- function(str, q="`") {
 }
 
 # convert an XML match into a Lint
-xml_nodes_to_lint <- function(xml, source_file, message, linter,
+xml_nodes_to_lint <- function(xml, source_file, message,
                               type = c("style", "warning", "error")) {
   type <- match.arg(type, c("style", "warning", "error"))
   line1 <- xml2::xml_attr(xml, "line1")[1]
@@ -218,8 +218,7 @@ xml_nodes_to_lint <- function(xml, source_file, message, linter,
     type = type,
     message = message,
     line = source_file$lines[line1],
-    ranges = list(c(col1, col2)),
-    linter = linter
+    ranges = list(c(col1, col2))
   ))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,7 +64,7 @@ names2 <- function(x) {
 
 linter_auto_name <- function(which = -3L) {
   call <- sys.call(which = which)
-  nm <- paste(deparse(call, 500L), collapse = "")
+  nm <- paste(deparse(call, 500L), collapse = " ")
   regex <- rex(start, one_or_more(alnum %or% "." %or% "_"))
   if (re_matches(nm, regex)) {
     match <- re_matches(nm, regex, locations = TRUE)
@@ -82,7 +82,7 @@ auto_names <- function(x) {
     if (inherits(x, "linter")) {
       attr(x, "name", exact = TRUE)
     } else {
-      paste(deparse(x, 500L), collapse = "")
+      paste(deparse(x, 500L), collapse = " ")
     }
   }
   defaults <- vapply(x[missing], default_name, character(1), USE.NAMES = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -64,7 +64,7 @@ names2 <- function(x) {
 
 linter_auto_name <- function(which = -3L) {
   call <- sys.call(which = which)
-  nm <- deparse(call)
+  nm <- paste(deparse(call, 500L), collapse = "")
   regex <- rex(start, one_or_more(alnum %or% "." %or% "_"))
   if (re_matches(nm, regex)) {
     match <- re_matches(nm, regex, locations = TRUE)

--- a/man/Lint.Rd
+++ b/man/Lint.Rd
@@ -30,7 +30,7 @@ Lint(
 
 \item{ranges}{a list of ranges on the line that should be emphasized.}
 
-\item{linter}{name of linter that created the Lint object.}
+\item{linter}{deprecated. No longer used.}
 }
 \value{
 an object of class 'lint'.

--- a/man/Linter.Rd
+++ b/man/Linter.Rd
@@ -4,10 +4,13 @@
 \alias{Linter}
 \title{Create a \code{linter} closure}
 \usage{
-Linter(fun)
+Linter(fun, name = linter_auto_name())
 }
 \arguments{
 \item{fun}{A function that takes a source file and returns \code{lint} objects.}
+
+\item{name}{Default name of the Linter.
+Lints produced by the linter will be labelled with \code{name} by default.}
 }
 \value{
 The same function with its class set to 'linter'.

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -8,7 +8,7 @@ test_that("returns the correct linting", {
     function() {
     b",
     rex("unexpected end of input"),
-    structure(function(...) NULL, class = "linter")
+    structure(function(...) NULL, class = "linter", name = "null")
   )
 
   linter <- equals_na_linter()

--- a/tests/testthat/test-lint_file.R
+++ b/tests/testthat/test-lint_file.R
@@ -140,6 +140,16 @@ test_that("compatibility warnings work", {
     fixed = "The use of linters of class 'function'"
   )
 
+  # Trigger compatibility in auto_names()
+  expect_warning(
+    expect_lint(
+      "a == NA",
+      "Use is.na",
+      linters = list(unclass(equals_na_linter()))
+    ),
+    fixed = "The use of linters of class 'function'"
+  )
+
   expect_error(
     expect_warning(
       lint("a <- 1\n", linters = function(two, arguments) NULL),

--- a/tests/testthat/test-make_linter_from_regex.R
+++ b/tests/testthat/test-make_linter_from_regex.R
@@ -1,5 +1,5 @@
 test_that("test make_linter_from_regex works", {
-  linter <- make_linter_from_regex("-", "no_dash_linter", "style", "Silly lint.")()
+  linter <- make_linter_from_regex("-", "style", "Silly lint.")()
   expect_lint("a <- 2L", "Silly lint.", linter)
   expect_lint("a = '2-3'", NULL, linter)
 })

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -22,25 +22,32 @@ test_that("it returns the input trimmed to the last full lint if one exists with
 test_that("as.data.frame.lints", {
   # A minimum lint
   expect_is(
-    l1 <- Lint("dummy.R",
-         line_number = 1L,
-         type = "style",
-         message = "",
-         line = ""),
+    l1 <- Lint(
+      "dummy.R",
+      line_number = 1L,
+      type = "style",
+      message = "",
+      line = ""
+    ),
     "lint"
   )
 
   # A larger lint
   expect_is(
-    l2 <- Lint("dummy.R",
-              line_number = 2L,
-              column_number = 6L,
-              type = "error",
-              message = "Under no circumstances is the use of foobar allowed.",
-              line = "a <- 1",
-              ranges = list(c(1, 2), c(10, 20)),
-              linter = "custom_linter"),
+    l2 <- Lint(
+      "dummy.R",
+      line_number = 2L,
+      column_number = 6L,
+      type = "error",
+      message = "Under no circumstances is the use of foobar allowed.",
+      line = "a <- 1",
+      ranges = list(c(1, 2), c(10, 20))),
     "lint"
+  )
+
+  expect_warning(
+    Lint("dummy.R", linter = "deprecated"),
+    fixed = "deprecated"
   )
 
   # Convert lints to data.frame
@@ -57,8 +64,9 @@ test_that("as.data.frame.lints", {
     type = c("style", "error"),
     message = c("", "Under no circumstances is the use of foobar allowed."),
     line = c("", "a <- 1"),
-    linter = c("", "custom_linter"),
-    stringsAsFactors = FALSE)
+    linter = c(NA_character_, NA_character_), # These are assigned in lint() now.
+    stringsAsFactors = FALSE
+  )
 
   expect_equal(
     df,
@@ -92,7 +100,7 @@ test_that("print.lint works", {
   l <- Lint(
     filename = "tmp", line_number = 1L, column_number = 3L,
     type = "warning", message = "this is a lint",
-    line = c(`1` = "\t\t1:length(x)"), ranges = list(c(3L, 3L)), linter = "lnt"
+    line = c(`1` = "\t\t1:length(x)"), ranges = list(c(3L, 3L))
   )
   expect_output(print(l), "  1:length(x)", fixed = TRUE)
 })

--- a/tests/testthat/test-methods.R
+++ b/tests/testthat/test-methods.R
@@ -47,7 +47,8 @@ test_that("as.data.frame.lints", {
 
   expect_warning(
     Lint("dummy.R", linter = "deprecated"),
-    fixed = "deprecated"
+    regexp = "deprecated",
+    fixed = TRUE
   )
 
   # Convert lints to data.frame

--- a/vignettes/creating_linters.Rmd
+++ b/vignettes/creating_linters.Rmd
@@ -16,21 +16,22 @@ A good example of a simple linter is the `assignment_linter`.
 #' @describeIn linters Check that '<-' is always used for assignment.
 #' @export
 assignment_linter <- function() {
-Linter(function(source_file) {
-  lapply(ids_with_token(source_file, "EQ_ASSIGN"),
-    function(id) {
-      parsed <- source_file$parsed_content[id, ]
-      Lint(
-        filename = source_file$filename,
-        line_number = parsed$line1,
-        column_number = parsed$col1,
-        type = "style",
-        message = "Use <-, not =, for assignment.",
-        line = source_file$lines[parsed$line1],
-        linter = "assignment_linter"
+  Linter(function(source_file) {
+    lapply(
+      ids_with_token(source_file, "EQ_ASSIGN"),
+      function(id) {
+        parsed <- source_file$parsed_content[id, ]
+        Lint(
+          filename = source_file$filename,
+          line_number = parsed$line1,
+          column_number = parsed$col1,
+          type = "style",
+          message = "Use <-, not =, for assignment.",
+          line = source_file$lines[parsed$line1]
         )
-    })
-})
+      }
+    )
+  })
 }
 ```
 
@@ -86,9 +87,8 @@ Lint(
   column_number = parsed$col1,
   type = "style",
   message = "Use <-, not =, for assignment.",
-  line = source_file$lines[parsed$line1],
-  linter = "assignment_linter"
-  )
+  line = source_file$lines[parsed$line1]
+)
 ```
 Lastly, build a `lint` object which describes the issue.  See `?Lint` for a
 description of the arguments. You do not have to return a lint for every


### PR DESCRIPTION
fixes #746

Things that should be done in this PR:

 - [x] remove `linter` argument from `Lint`. It's overwritten during `lint()` anyway.
 - [x] refactor `expect_lint()` to nevertheless recognize `linter` as a `lint_fields` despite not being an argument of `Lint()`.
 - [x] document the new behaviour.
 - [x] add NEWS bullet.