### PR TITLE
Define and validate linters

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,6 +1,6 @@
 linters: with_defaults( # The following TODOs are part of an effort to have {lintr} lint-free (#584)
    line_length_linter = line_length_linter(120),
-   cyclocomp_linter = cyclocomp_linter(30) # TODO reduce to 15
+   cyclocomp_linter = cyclocomp_linter(28) # TODO reduce to 15
  )
 exclusions: list(
   "inst/doc/creating_linters.R" = 1,

--- a/R/lint.R
+++ b/R/lint.R
@@ -126,54 +126,6 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
   res
 }
 
-define_linters <- function(linters = NULL) {
-  if (is.null(linters)) {
-    linters <- settings$linters
-    names(linters) <- auto_names(linters)
-  } else if (!is.list(linters)) {
-    name <- deparse(substitute(linters))
-    linters <- list(linters)
-    names(linters) <- name
-  } else {
-    names(linters) <- auto_names(linters)
-  }
-  linters
-}
-
-validate_linter_object <- function(linter, name) {
-  if (inherits(linter, "linter")) {
-  } else if (is.function(linter)) {
-    if (is.null(formals(linter))) {
-      old <- "Passing linters as variables"
-      new <- "a call to the linters (see ?linters)"
-      lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
-                       type = "")
-      linter <- linter()
-    } else {
-      old <- "The use of linters of class 'function'"
-      new <- "linters classed as 'linter' (see ?Linter)"
-      lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
-                       type = "")
-      linter <- Linter(linter)
-    }
-  } else {
-    stop(gettextf("Expected '%s' to be of class 'linter', not '%s'",
-                  name, class(linter)[[1L]]))
-  }
-  linter
-}
-
-reorder_lints <- function(lints) {
-  files <- vapply(lints, `[[`, character(1), "filename")
-  lines <- vapply(lints, `[[`, integer(1), "line_number")
-  columns <- vapply(lints, `[[`, integer(1), "column_number")
-  lints[order(
-    files,
-    lines,
-    columns
-  )]
-}
-
 #' Lint a directory
 #'
 #' Apply one or more linters to all of the R files in a directory
@@ -326,6 +278,54 @@ lint_package <- function(path = ".", relative_path = TRUE, ...,
   lints
 }
 
+
+define_linters <- function(linters = NULL) {
+  if (is.null(linters)) {
+    linters <- settings$linters
+    names(linters) <- auto_names(linters)
+  } else if (!is.list(linters)) {
+    name <- deparse(substitute(linters))
+    linters <- list(linters)
+    names(linters) <- name
+  } else {
+    names(linters) <- auto_names(linters)
+  }
+  linters
+}
+
+validate_linter_object <- function(linter, name) {
+  if (inherits(linter, "linter")) {
+  } else if (is.function(linter)) {
+    if (is.null(formals(linter))) {
+      old <- "Passing linters as variables"
+      new <- "a call to the linters (see ?linters)"
+      lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
+                       type = "")
+      linter <- linter()
+    } else {
+      old <- "The use of linters of class 'function'"
+      new <- "linters classed as 'linter' (see ?Linter)"
+      lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
+                       type = "")
+      linter <- Linter(linter)
+    }
+  } else {
+    stop(gettextf("Expected '%s' to be of class 'linter', not '%s'",
+                  name, class(linter)[[1L]]))
+  }
+  linter
+}
+
+reorder_lints <- function(lints) {
+  files <- vapply(lints, `[[`, character(1), "filename")
+  lines <- vapply(lints, `[[`, integer(1), "line_number")
+  columns <- vapply(lints, `[[`, integer(1), "column_number")
+  lints[order(
+    files,
+    lines,
+    columns
+  )]
+}
 
 has_description <- function(path) {
   file.exists(file.path(path, "DESCRIPTION"))

--- a/R/lint.R
+++ b/R/lint.R
@@ -52,43 +52,8 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
     on.exit(clear_settings, add = TRUE)
   }
 
-  if (is.null(linters)) {
-    linters <- settings$linters
-    names(linters) <- auto_names(linters)
-  } else if (!is.list(linters)) {
-    name <- deparse(substitute(linters))
-    linters <- list(linters)
-    names(linters) <- name
-  } else {
-    names(linters) <- auto_names(linters)
-  }
-
-  linters <- Map(
-    function(obj, name) {
-      if (inherits(obj, "linter")) {
-      } else if (is.function(obj)) {
-        if (is.null(formals(obj))) {
-          old <- "Passing linters as variables"
-          new <- "a call to the linters (see ?linters)"
-          lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
-                           type = "")
-          obj <- obj()
-        } else {
-          old <- "The use of linters of class 'function'"
-          new <- "linters classed as 'linter' (see ?Linter)"
-          lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
-                           type = "")
-          obj <- Linter(obj)
-        }
-      } else {
-        stop(gettextf("Expected '%s' to be of class 'linter', not '%s'",
-                      name, class(obj)[[1L]]))
-      }
-      obj
-    },
-    linters,
-    names(linters)
-  )
+  linters <- define_linters(linters)
+  linters <- Map(validate_linter_object, linters, names(linters))
 
   lints <- list()
   itr <- 0
@@ -159,6 +124,43 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
     }
   }
   res
+}
+
+define_linters <- function(linters = NULL) {
+  if (is.null(linters)) {
+    linters <- settings$linters
+    names(linters) <- auto_names(linters)
+  } else if (!is.list(linters)) {
+    name <- deparse(substitute(linters))
+    linters <- list(linters)
+    names(linters) <- name
+  } else {
+    names(linters) <- auto_names(linters)
+  }
+  linters
+}
+
+validate_linter_object <- function(linter, name) {
+  if (inherits(linter, "linter")) {
+  } else if (is.function(linter)) {
+    if (is.null(formals(linter))) {
+      old <- "Passing linters as variables"
+      new <- "a call to the linters (see ?linters)"
+      lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
+                       type = "")
+      linter <- linter()
+    } else {
+      old <- "The use of linters of class 'function'"
+      new <- "linters classed as 'linter' (see ?Linter)"
+      lintr_deprecated(old = old, new = new, version = "2.0.1.9001",
+                       type = "")
+      linter <- Linter(linter)
+    }
+  } else {
+    stop(gettextf("Expected '%s' to be of class 'linter', not '%s'",
+                  name, class(linter)[[1L]]))
+  }
+  linter
 }
 
 reorder_lints <- function(lints) {


### PR DESCRIPTION
Following https://github.com/jimhester/lintr/commit/af6ec3078aeefe8aeeaf76958280199e03319406 the cyclomatic complexity of lint() went up to 34. Since we have two linting steps in the PR review process, this increase in cyclomatic complexity would have been easy to overlook at the time.

The current changes brings cyclomatic-complexity of lint() down to 28 (which is now the threshold set in .lintr), and cleans up the lint function a tiny bit.
The code for defining the set of linters used inside lint(), and for checking that they are all Linter objects has been extracted into helper functions.

I'm attempting to make other changes to lint(); but think the changes here should be included first.

All non-exported helper functions that are in lint.R have been pushed to the bottom of the file for readability.