### PR TITLE
Add cache-test fixtures

### DIFF
--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1,6 +1,31 @@
+# Fixtures
+
+fixtures <- list()
+
+fixtures$retrieve_lint <- function() {
+  file_name <- "R/test.R"
+  lines <- c("foobar1", "foobar2", "foobar3")
+  lints <- list(
+    Lint(file_name, 1, line = "foobar1"),
+    Lint(file_name, 2, line = "foobar2"),
+    Lint(file_name, 3, line = "foobar3")
+  )
+  expr <- list(content = paste(collapse = "\n", lines))
+  list(
+    lines = lines,
+    linters = list(),
+    lints = lints,
+    expr = expr
+  )
+}
+
+# Helper functions
+
 fhash <- function(filename) {
   digest::digest(filename, algo = "sha1")
 }
+
+# Tests
 
 test_that("clear_cache deletes the file if a file is given", {
   mockery::stub(clear_cache, "read_settings", function(...) invisible(...))
@@ -182,25 +207,6 @@ test_that("cache_lint generates different caches for different linters", {
 
   expect_equal(length(ls(e1)), 2)
 })
-
-fixtures <- list()
-
-fixtures$retrieve_lint <- function() {
-  file_name <- "R/test.R"
-  lines <- c("foobar1", "foobar2", "foobar3")
-  lints <- list(
-    Lint(file_name, 1, line = "foobar1"),
-    Lint(file_name, 2, line = "foobar2"),
-    Lint(file_name, 3, line = "foobar3")
-  )
-  expr <- list(content = paste(collapse = "\n", lines))
-  list(
-    lines = lines,
-    linters = list(),
-    lints = lints,
-    expr = expr
-  )
-}
 
 test_that("retrieve_lint returns the same lints if nothing has changed", {
   test_data <- fixtures$retrieve_lint()

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -253,29 +253,28 @@ test_that("retrieve_lint returns the same lints with fixed line numbers if lines
 })
 
 test_that("retrieve_lint returns the same lints with lines added below", {
+  test_data <- fixtures$retrieve_lint()
+
   e1 <- new.env(parent = emptyenv())
 
-  lines1 <- c("foobar1", "foobar2", "foobar3")
-  lines2 <- c("foobar1", "foobar2", "foobar3", "")
+  lines1 <- test_data[["lines"]]
+  lines2 <- c(lines1, "")
 
-  lints1 <- list(
-    Lint("R/test.R", 1, line = "foobar1"),
-    Lint("R/test.R", 2, line = "foobar2"),
-    Lint("R/test.R", 3, line = "foobar3")
+  cache_lint(
+    cache = e1,
+    expr = test_data[["expr"]],
+    linter = test_data[["linters"]],
+    lints = test_data[["lints"]]
   )
 
-  expr1 <- list(content = paste(collapse = "\n", lines1))
-  cache_lint(cache = e1,
-             expr = expr1,
-             linter = list(),
-             lints = lints1)
+  t1 <- retrieve_lint(
+    cache = e1,
+    expr = test_data[["expr"]],
+    linter = test_data[["linters"]],
+    lines = lines2
+  )
 
-  t1 <- retrieve_lint(cache = e1,
-                      expr = expr1,
-                      linter = list(),
-                      lines2)
-
-  expect_equal(t1, lints1)
+  expect_equal(t1, test_data[["lints"]])
 })
 
 test_that("retrieve_lint returns the same lints with fixed line numbers if lines added between", {

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -224,7 +224,9 @@ test_that("retrieve_lint returns the same lints if nothing has changed", {
   expect_equal(t1, test_data[["lints"]])
 })
 
-test_that("retrieve_lint returns the same lints with fixed line numbers if lines added above", {
+test_that(
+  p("retrieve_lint returns the same lints with fixed line numbers if lines",
+    " added above"), {
   test_data <- fixtures$retrieve_lint()
 
   e1 <- new.env(parent = emptyenv())
@@ -277,28 +279,31 @@ test_that("retrieve_lint returns the same lints with lines added below", {
   expect_equal(t1, test_data[["lints"]])
 })
 
-test_that("retrieve_lint returns the same lints with fixed line numbers if lines added between", {
+test_that(
+  p("retrieve_lint returns the same lints with fixed line numbers if lines",
+    " added between"), {
+  test_data <- fixtures$retrieve_lint()
+
   e1 <- new.env(parent = emptyenv())
 
-  lines1 <- c("foobar1", "foobar2", "foobar3")
-  lines2 <- c("foobar1", "", "foobar2", "foobar3", "")
+  lines1 <- test_data[["lines"]]
+  lines2 <- c(lines1[1], "", lines1[2:3], "")
 
-  lints1 <- list(
-    Lint("R/test.R", 1, line = "foobar1"),
-    Lint("R/test.R", 2, line = "foobar2"),
-    Lint("R/test.R", 3, line = "foobar3")
+  lints1 <- test_data[["lints"]]
+
+  cache_lint(
+    cache = e1,
+    expr = test_data[["expr"]],
+    linter = test_data[["linters"]],
+    lints = lints1
   )
 
-  expr1 <- list(content = paste(collapse = "\n", lines1))
-  cache_lint(cache = e1,
-             expr = expr1,
-             linter = list(),
-             lints = lints1)
-
-  t1 <- retrieve_lint(cache = e1,
-                      expr = expr1,
-                      linter = list(),
-                      lines2)
+  t1 <- retrieve_lint(
+    cache = e1,
+    expr = test_data[["expr"]],
+    linter = test_data[["linters"]],
+    lines = lines2
+  )
 
   expect_equal(t1[[1]]$line_number, lints1[[1]]$line_number)
   expect_equal(t1[[2]]$line_number, lints1[[2]]$line_number + 1)

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -225,31 +225,31 @@ test_that("retrieve_lint returns the same lints if nothing has changed", {
 })
 
 test_that("retrieve_lint returns the same lints with fixed line numbers if lines added above", {
+  test_data <- fixtures$retrieve_lint()
+
   e1 <- new.env(parent = emptyenv())
 
-  lines1 <- c("foobar1", "foobar2", "foobar3")
-  lines2 <- c("", "foobar1", "foobar2", "foobar3")
+  lines1 <- test_data[["lines"]]
+  lines2 <- c("", lines1)
+  lints <- test_data[["lints"]]
 
-  lints1 <- list(
-    Lint("R/test.R", 1, line = "foobar1"),
-    Lint("R/test.R", 2, line = "foobar2"),
-    Lint("R/test.R", 3, line = "foobar3")
+  cache_lint(
+    cache = e1,
+    expr = test_data[["expr"]],
+    linter = test_data[["linters"]],
+    lints = lints
   )
 
-  expr1 <- list(content = paste(collapse = "\n", lines1))
-  cache_lint(cache = e1,
-             expr = expr1,
-             linter = list(),
-             lints = lints1)
+  t1 <- retrieve_lint(
+    cache = e1,
+    expr = test_data[["expr"]],
+    linter = test_data[["linters"]],
+    lines = lines2
+  )
 
-  t1 <- retrieve_lint(cache = e1,
-                      expr = expr1,
-                      linter = list(),
-                      lines2)
-
-  expect_equal(t1[[1]]$line_number, lints1[[1]]$line_number + 1)
-  expect_equal(t1[[2]]$line_number, lints1[[2]]$line_number + 1)
-  expect_equal(t1[[3]]$line_number, lints1[[3]]$line_number + 1)
+  expect_equal(t1[[1]]$line_number, lints[[1]]$line_number + 1)
+  expect_equal(t1[[2]]$line_number, lints[[2]]$line_number + 1)
+  expect_equal(t1[[3]]$line_number, lints[[3]]$line_number + 1)
 })
 
 test_that("retrieve_lint returns the same lints with lines added below", {

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -410,7 +410,7 @@ test_that("it works outside of a package", {
   )
 })
 
-test_that("chache = TRUE workflow works", {
+test_that("cache = TRUE workflow works", {
   # Need a test structure with a safe to load .lintr
   pkg <- "dummy_packages/package"
   files <- normalizePath(list.files(pkg, recursive = TRUE, full.names = TRUE))

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -183,30 +183,45 @@ test_that("cache_lint generates different caches for different linters", {
   expect_equal(length(ls(e1)), 2)
 })
 
+fixtures <- list()
+
+fixtures$retrieve_lint <- function() {
+  file_name <- "R/test.R"
+  lines <- c("foobar1", "foobar2", "foobar3")
+  lints <- list(
+    Lint(file_name, 1, line = "foobar1"),
+    Lint(file_name, 2, line = "foobar2"),
+    Lint(file_name, 3, line = "foobar3")
+  )
+  expr <- list(content = paste(collapse = "\n", lines))
+  list(
+    lines = lines,
+    linters = list(),
+    lints = lints,
+    expr = expr
+  )
+}
+
 test_that("retrieve_lint returns the same lints if nothing has changed", {
+  test_data <- fixtures$retrieve_lint()
+
   e1 <- new.env(parent = emptyenv())
 
-  lines1 <- c("foobar1", "foobar2", "foobar3")
-
-  lints1 <- list(
-    Lint("R/test.R", 1, line = "foobar1"),
-    Lint("R/test.R", 2, line = "foobar2"),
-    Lint("R/test.R", 3, line = "foobar3")
+  cache_lint(
+    cache = e1,
+    expr = test_data[["expr"]],
+    linter = test_data[["linters"]],
+    lints = test_data[["lints"]]
   )
 
-  expr1 <- list(content = paste(collapse = "\n", lines1))
-  cache_lint(cache = e1,
-             expr = expr1,
-             linter = list(),
-             lints = lints1)
+  t1 <- retrieve_lint(
+    cache = e1,
+    expr = test_data[["expr"]],
+    linter = test_data[["linters"]],
+    lines = test_data[["lines"]]
+  )
 
-  t1 <- retrieve_lint(cache = e1,
-                      expr = expr1,
-                      linter = list(),
-                      lines1
-                      )
-
-  expect_equal(t1, lints1)
+  expect_equal(t1, test_data[["lints"]])
 })
 
 test_that("retrieve_lint returns the same lints with fixed line numbers if lines added above", {

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -27,6 +27,8 @@ fhash <- function(filename) {
 
 # Tests
 
+# `clear_cache`
+
 test_that("clear_cache deletes the file if a file is given", {
   mockery::stub(clear_cache, "read_settings", function(...) invisible(...))
   mockery::stub(clear_cache, "unlink", function(...) list(...))
@@ -47,6 +49,8 @@ test_that("clear_cache deletes the directory if no file is given", {
 
   expect_equal(clear_cache(file = NULL, path = "."), list(".", recursive = TRUE))
 })
+
+# `load_cache`
 
 test_that("load_cache loads the saved file in a new empty environment", {
   with_mock(
@@ -79,6 +83,8 @@ test_that("load_cache returns an empty environment if no cache file exists", {
     expect_equal(ls(e2), character(0))
   )
 })
+
+# `save_cache`
 
 test_that("save_cache creates a directory if needed", {
   with_mock(
@@ -140,6 +146,8 @@ test_that("save_cache saves all non-hidden objects from the environment", {
   )
 })
 
+# `cache_file`
+
 test_that("cache_file generates the same cache with different lints", {
   e1 <- new.env(parent = emptyenv())
 
@@ -166,6 +174,8 @@ test_that("cache_file generates different caches for different linters", {
   expect_equal(length(ls(e1)), 2)
 })
 
+# `retrieve_file`
+
 test_that("retrieve_file returns NULL if there is no cached result", {
   e1 <- new.env(parent = emptyenv())
 
@@ -187,6 +197,8 @@ test_that("retrieve_file returns the cached result if found", {
   expect_equal(retrieve_file(e1, f1, list()), list("foobar"))
 })
 
+# `cache_lint`
+
 test_that("cache_lint generates the same cache with different lints", {
   e1 <- new.env(parent = emptyenv())
 
@@ -207,6 +219,8 @@ test_that("cache_lint generates different caches for different linters", {
 
   expect_equal(length(ls(e1)), 2)
 })
+
+# `retrieve_lint`
 
 test_that("retrieve_lint returns the same lints if nothing has changed", {
   test_data <- fixtures$retrieve_lint()
@@ -316,6 +330,8 @@ test_that(
   expect_equal(t1[[3]]$line_number, lints1[[3]]$line_number + 1)
 })
 
+# `has_lint`
+
 test_that("has_lint returns FALSE if there is no cached result", {
   e1 <- new.env(parent = emptyenv())
 
@@ -342,6 +358,8 @@ test_that("has_lint distinguishes global expressions from line expression with s
   global_expr <- list(content = same_content, file_lines = character())
   expect_false(has_lint(e1, global_expr, list()))
 })
+
+# `find_new_line`
 
 test_that("find_new_line returns the same if the line is the same", {
   t1 <- c("foobar1",
@@ -375,6 +393,8 @@ test_that("find_new_line returns the correct line if it is after the current lin
 
   expect_equal(find_new_line(3, "foobar3", t1), 3)
 })
+
+#
 
 test_that("lint with cache uses the provided relative cache directory", {
   path <- "./my_cache_dir"


### PR DESCRIPTION
Much of the data used in the tests for 'retrieve_lint' was duplicated across tests.
Added a fixture within the 'test-cache.R' context to set up this data.

This will be useful if we introduce a class to handle cacheing logic (re https://github.com/jimhester/lintr/pull/747)