### PR TITLE
Use XPath for T_and_F_symbol_linter and fix false positives

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,7 @@
 * `trailing_blank_lines_linter()` now also lints files without a terminal newline (#675, @AshesITR)
 * `object_name_linter()` now correctly detects imported functions when linting packages (#642, @AshesITR)
 * Consistent access to linters through a function call, even for linters without parameters (#245, @fangly, @AshesITR, and @MichaelChirico)
+* `T_and_F_symbol_linter()` no longer lints occurrences of `T` and `F` when used as variable names or subsetting names (#657, @AshesITR)
 
 # lintr 2.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -55,7 +55,8 @@
 * `trailing_blank_lines_linter()` now also lints files without a terminal newline (#675, @AshesITR)
 * `object_name_linter()` now correctly detects imported functions when linting packages (#642, @AshesITR)
 * Consistent access to linters through a function call, even for linters without parameters (#245, @fangly, @AshesITR, and @MichaelChirico)
-* `T_and_F_symbol_linter()` no longer lints occurrences of `T` and `F` when used as variable names or subsetting names (#657, @AshesITR)
+* `T_and_F_symbol_linter()` no longer lints occurrences of `T` and `F` when used for subsetting and gives a better 
+  message when used as variable names (#657, @AshesITR)
 
 # lintr 2.0.1
 

--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -41,7 +41,6 @@ T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
         xml = expr,
         source_file = source_file,
         message = message,
-        linter = "T_and_F_symbol_linter",
         type = "style",
         offset = 1L
       )

--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -9,22 +9,25 @@ T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
     xpath <- paste0(
       "//SYMBOL[",
       "(text() = 'T' or text() = 'F')", # T or F symbol
-      " and count(preceding-sibling::OP-DOLLAR) = 0", # not part of a $-subset expression
-      " and count(parent::expr/following-sibling::LEFT_ASSIGN) = 0", # not target of left assignment
-      " and count(parent::expr/preceding-sibling::RIGHT_ASSIGN) = 0", # not target of right assignment
-      " and count(parent::expr/following-sibling::EQ_ASSIGN) = 0", # not target of equals assignment
+      " and not(preceding-sibling::OP-DOLLAR)", # not part of a $-subset expression
+      " and not(parent::expr[",
+      "  following-sibling::LEFT_ASSIGN", # not target of left assignment
+      "  or preceding-sibling::RIGHT_ASSIGN", # not target of right assignment
+      "  or following-sibling::EQ_ASSIGN", # not target of equals assignment
+      "])",
       "]"
     )
 
     xpath_assignment <- paste0(
       "//SYMBOL[",
       "(text() = 'T' or text() = 'F')", # T or F symbol
-      " and count(preceding-sibling::OP-DOLLAR) = 0", # not part of a $-subset expression
-      " and (",
-      " count(parent::expr/following-sibling::LEFT_ASSIGN) > 0", # target of left assignment
-      " or count(parent::expr/preceding-sibling::RIGHT_ASSIGN) > 0", # target of right assignment
-      " or count(parent::expr/following-sibling::EQ_ASSIGN) > 0", # target of equals assignment
-      ")]"
+      " and not(preceding-sibling::OP-DOLLAR)", # not part of a $-subset expression
+      " and parent::expr[", #, but ...
+      "  following-sibling::LEFT_ASSIGN", # target of left assignment
+      "  or preceding-sibling::RIGHT_ASSIGN", # target of right assignment
+      "  or following-sibling::EQ_ASSIGN", # target of equals assignment
+      " ]",
+      "]"
     )
 
     bad_exprs <- xml2::xml_find_all(source_file$xml_parsed_content, xpath)

--- a/R/T_and_F_symbol_linter.R
+++ b/R/T_and_F_symbol_linter.R
@@ -16,12 +16,24 @@ T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
       "]"
     )
 
-    bad_exprs <- xml2::xml_find_all(source_file$xml_parsed_content, xpath)
+    xpath_assignment <- paste0(
+      "//SYMBOL[",
+      "(text() = 'T' or text() = 'F')", # T or F symbol
+      " and count(preceding-sibling::OP-DOLLAR) = 0", # not part of a $-subset expression
+      " and (",
+      " count(parent::expr/following-sibling::LEFT_ASSIGN) > 0", # target of left assignment
+      " or count(parent::expr/preceding-sibling::RIGHT_ASSIGN) > 0", # target of right assignment
+      " or count(parent::expr/following-sibling::EQ_ASSIGN) > 0", # target of equals assignment
+      ")]"
+    )
 
-    lapply(bad_exprs, function(expr) {
+    bad_exprs <- xml2::xml_find_all(source_file$xml_parsed_content, xpath)
+    bad_assigns <- xml2::xml_find_all(source_file$xml_parsed_content, xpath_assignment)
+
+    make_lint <- function(expr, fmt) {
       symbol <- xml2::xml_text(expr)
       replacement <- switch(symbol, "T" = "TRUE", "F" = "FALSE")
-      message <- sprintf("Use %s instead of the symbol %s.", replacement, symbol)
+      message <- sprintf(fmt, replacement, symbol)
       xml_nodes_to_lint(
         xml = expr,
         source_file = source_file,
@@ -30,6 +42,17 @@ T_and_F_symbol_linter <- function() { # nolint: object_name_linter.
         type = "style",
         offset = 1L
       )
-    })
+    }
+
+    c(
+      lapply(
+        bad_exprs, make_lint,
+        fmt = "Use %s instead of the symbol %s."
+      ),
+      lapply(
+        bad_assigns, make_lint,
+        fmt = "Don't use %2$s as a variable name, as it can break code relying on %2$s being %1$s."
+      )
+    )
   })
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -219,7 +219,7 @@ xml_nodes_to_lint <- function(xml, source_file, message,
     type = type,
     message = message,
     line = source_file$lines[line1],
-    ranges = list(c(col1, col2))
+    ranges = list(c(col1 - offset, col2))
   ))
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -201,13 +201,14 @@ unescape <- function(str, q="`") {
 
 # convert an XML match into a Lint
 xml_nodes_to_lint <- function(xml, source_file, message,
-                              type = c("style", "warning", "error")) {
+                              type = c("style", "warning", "error"),
+                              offset = 0L) {
   type <- match.arg(type, c("style", "warning", "error"))
   line1 <- xml2::xml_attr(xml, "line1")[1]
-  col1 <- as.integer(xml2::xml_attr(xml, "col1"))
+  col1 <- as.integer(xml2::xml_attr(xml, "col1")) + offset
 
   if (xml2::xml_attr(xml, "line2") == line1) {
-    col2 <- as.integer(xml2::xml_attr(xml, "col2"))
+    col2 <- as.integer(xml2::xml_attr(xml, "col2")) + offset
   } else {
     col2 <- nchar(source_file$lines[line1])
   }

--- a/tests/testthat/test-T_and_F_symbol_linter.R
+++ b/tests/testthat/test-T_and_F_symbol_linter.R
@@ -2,12 +2,16 @@ test_that("returns the correct linting", {
   linter <- T_and_F_symbol_linter()
   msg_true <- "Use TRUE instead of the symbol T."
   msg_false <- "Use FALSE instead of the symbol F."
+  msg_variable_true <- "Don't use T as a variable name, as it can break code relying on T being TRUE."
+  msg_variable_false <- "Don't use F as a variable name, as it can break code relying on F being FALSE."
 
   expect_lint("FALSE", NULL, linter)
   expect_lint("TRUE", NULL, linter)
   expect_lint("x <- \"TRUE master vs FALSE slave\"", NULL, linter)
   expect_lint("T", list(message = msg_true, line_number = 1L, column_number = 2L), linter)
   expect_lint("F", list(message = msg_false, line_number = 1L, column_number = 2L), linter)
+  expect_lint("T = 42", list(message = msg_variable_true, line_number = 1L, column_number = 2L), linter)
+  expect_lint("F = 42", list(message = msg_variable_false, line_number = 1L, column_number = 2L), linter)
   expect_lint(
     "for (i in 1:10) {x <- c(T, TRUE, F, FALSE)}",
     list(
@@ -31,7 +35,11 @@ test_that("returns the correct linting", {
       F = \"foo2\"
       \"foo3\" -> T
     "),
-    NULL,
+    list(
+      list(message = msg_variable_true),
+      list(message = msg_variable_false),
+      list(message = msg_variable_true)
+    ),
     linter
   )
 })

--- a/tests/testthat/test-T_and_F_symbol_linter.R
+++ b/tests/testthat/test-T_and_F_symbol_linter.R
@@ -2,15 +2,36 @@ test_that("returns the correct linting", {
   linter <- T_and_F_symbol_linter()
   msg_true <- "Use TRUE instead of the symbol T."
   msg_false <- "Use FALSE instead of the symbol F."
+
   expect_lint("FALSE", NULL, linter)
   expect_lint("TRUE", NULL, linter)
   expect_lint("x <- \"TRUE master vs FALSE slave\"", NULL, linter)
   expect_lint("T", list(message = msg_true, line_number = 1L, column_number = 2L), linter)
   expect_lint("F", list(message = msg_false, line_number = 1L, column_number = 2L), linter)
-  expect_lint("for (i in 1:10) {x <- c(T, TRUE, F, FALSE)}",
-              list(
-                list(message = msg_true, line_number = 1L, column_number = 26L),
-                list(message = msg_false, line_number = 1L, column_number = 35L)
-              ),
-              linter)
+  expect_lint(
+    "for (i in 1:10) {x <- c(T, TRUE, F, FALSE)}",
+    list(
+      list(message = msg_true, line_number = 1L, column_number = 26L),
+      list(message = msg_false, line_number = 1L, column_number = 35L)
+    ),
+    linter
+  )
+
+  # Regression test for #657
+  expect_lint(
+    trim_some("
+      x <- list(
+        T = 42L,
+        F = 21L
+      )
+
+      x$F <- 42L
+
+      T <- \"foo\"
+      F = \"foo2\"
+      \"foo3\" -> T
+    "),
+    NULL,
+    linter
+  )
 })

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -7,11 +7,11 @@ test_that("it excludes properly", {
 
   t1 <- lint("exclusions-test", parse_settings = FALSE)
 
-  expect_equal(length(t1), 8)
+  expect_equal(length(t1), 7)
 
   t2 <- lint("exclusions-test", exclusions = list("exclusions-test" = 4), parse_settings = FALSE)
 
-  expect_equal(length(t2), 7)
+  expect_equal(length(t2), 6)
 
   t3 <- lint("exclusions-test", exclusions = list("exclusions-test"), parse_settings = FALSE)
 
@@ -22,7 +22,7 @@ test_that("it excludes properly", {
   for (info in sprintf("caching: pass %s", 1:4)) {
     t4 <- lint("exclusions-test", cache = cache_path, parse_settings = FALSE)
 
-    expect_equal(length(t4), 8, info = info)
+    expect_equal(length(t4), 7, info = info)
   }
 })
 

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -7,11 +7,11 @@ test_that("it excludes properly", {
 
   t1 <- lint("exclusions-test", parse_settings = FALSE)
 
-  expect_equal(length(t1), 7)
+  expect_equal(length(t1), 8)
 
   t2 <- lint("exclusions-test", exclusions = list("exclusions-test" = 4), parse_settings = FALSE)
 
-  expect_equal(length(t2), 6)
+  expect_equal(length(t2), 7)
 
   t3 <- lint("exclusions-test", exclusions = list("exclusions-test"), parse_settings = FALSE)
 
@@ -22,7 +22,7 @@ test_that("it excludes properly", {
   for (info in sprintf("caching: pass %s", 1:4)) {
     t4 <- lint("exclusions-test", cache = cache_path, parse_settings = FALSE)
 
-    expect_equal(length(t4), 7, info = info)
+    expect_equal(length(t4), 8, info = info)
   }
 })
 


### PR DESCRIPTION
fixes #657

 - [x] implement fix
 - [x] add regression test
 - [x] add NEWS bullet

Migrating to XPath makes adding other exceptions easier as well.
Had to add the argument `offset` to `xml_nodes_to_lint` to keep the column numbers unchanged.