### PR TITLE
Ignore symbols used for subsetting in `object_name_linter`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@
 * `object_usage_linter()` now correctly reports usage warnings spanning multiple lines (#507, @AshesITR)
 * `T_and_F_symbol_linter()` no longer lints occurrences of `T` and `F` when used for subsetting and gives a better 
   message when used as variable names (#657, @AshesITR)
+* `object_name_linter()` no longer lints names used for subsetting (#582, @AshesITR)
 
 # lintr 2.0.1
 

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -43,6 +43,21 @@ object_name_linter <- function(styles = c("snake_case", "symbols")) {
       " ])",
       "]",
 
+      " | ",
+
+      "//STR_CONST[",
+      " not(preceding-sibling::OP-DOLLAR)",
+      " and ancestor::expr[",
+      "  following-sibling::LEFT_ASSIGN",
+      "  or preceding-sibling::RIGHT_ASSIGN",
+      "  or following-sibling::EQ_ASSIGN",
+      " ]",
+      " and not(ancestor::expr[",
+      "  preceding-sibling::OP-LEFT-BRACKET",
+      "  or preceding-sibling::LBB",
+      " ])",
+      "]",
+
       # Or
       " | ",
 

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -37,6 +37,10 @@ object_name_linter <- function(styles = c("snake_case", "symbols")) {
       "  or preceding-sibling::RIGHT_ASSIGN",
       "  or following-sibling::EQ_ASSIGN",
       " ]",
+      " and not(ancestor::expr[",
+      "  preceding-sibling::OP-LEFT-BRACKET",
+      "  or preceding-sibling::LBB",
+      " ])",
       "]",
 
       # Or

--- a/R/object_name_linters.R
+++ b/R/object_name_linters.R
@@ -29,14 +29,15 @@ object_name_linter <- function(styles = c("snake_case", "symbols")) {
     xml <- source_file$full_xml_parsed_content
 
     xpath <- paste0(
-      # Left hand assignments
-      "//expr[SYMBOL or STR_CONST][following-sibling::LEFT_ASSIGN or following-sibling::EQ_ASSIGN]/*",
-
-      # Or
-      " | ",
-
-      # Right hand assignments
-      "//expr[SYMBOL or STR_CONST][preceding-sibling::RIGHT_ASSIGN]/*",
+      # assignments
+      "//SYMBOL[",
+      " not(preceding-sibling::OP-DOLLAR)",
+      " and ancestor::expr[",
+      "  following-sibling::LEFT_ASSIGN",
+      "  or preceding-sibling::RIGHT_ASSIGN",
+      "  or following-sibling::EQ_ASSIGN",
+      " ]",
+      "]",
 
       # Or
       " | ",
@@ -49,7 +50,7 @@ object_name_linter <- function(styles = c("snake_case", "symbols")) {
 
     # Retrieve assigned name
     nms <- strip_names(
-      xml2::xml_text(xml2::xml_find_first(assignments, "./text()"))
+      xml2::xml_text(assignments)
     )
 
     generics <- strip_names(c(

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -38,8 +38,8 @@ test_that("styles are correctly identified", {
 
 test_that("linter ignores some objects", {
   # names for which style check is ignored
-  expect_lint("`%x%` <- t", NULL, object_name_linter("snake_case")) # operator
   expect_lint("`%X%` <- t", NULL, object_name_linter("SNAKE_CASE")) # operator
+  expect_lint("`%x%` <- t", NULL, object_name_linter("snake_case")) # operator
   expect_lint("`t.test` <- t", NULL, object_name_linter("UPPERCASE")) # std pkg
   expect_lint(".Deprecated('x')", NULL, object_name_linter("lowercase")) # std pkg
   expect_lint("print.foo <- t", NULL, object_name_linter("CamelCase")) # S3 generic
@@ -90,4 +90,15 @@ test_that("linter accepts vector of styles", {
     list(message = msg, line_number = 3L, column_number = 1L),
     linter
   )
+})
+
+test_that("dollar subsetting only lints the first expression", {
+  # Regression test for #582
+  linter <- object_name_linter()
+  msg <- "Variable and function name style should be snake_case or symbols."
+
+  expect_lint("my_var$MY_COL <- 42L", NULL, linter)
+  expect_lint("MY_VAR$MY_COL <- 42L", msg, linter)
+  expect_lint("my_var$MY_SUB$MY_COL <- 42L", NULL, linter)
+  expect_lint("MY_VAR$MY_SUB$MY_COL <- 42L", msg, linter)
 })

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -102,3 +102,16 @@ test_that("dollar subsetting only lints the first expression", {
   expect_lint("my_var$MY_SUB$MY_COL <- 42L", NULL, linter)
   expect_lint("MY_VAR$MY_SUB$MY_COL <- 42L", msg, linter)
 })
+
+test_that("assignment targets of compound lhs are correctly identified", {
+  linter <- object_name_linter()
+  msg <- "Variable and function name style should be snake_case or symbols."
+
+  expect_lint("good_name[badName] <- badName2", NULL, linter)
+  expect_lint("good_name[1L][badName] <- badName2", NULL, linter)
+  expect_lint("good_name[[badName]] <- badName2", NULL, linter)
+  expect_lint("good_name[[1L]][[badName]] <- badName2", NULL, linter)
+  expect_lint("good_name[[fun(badName)]] <- badName2", NULL, linter)
+  expect_lint("setter(badName) <- good_name", msg, linter)
+  expect_lint("setter(good_name[[badName]]) <- good_name2", NULL, linter)
+})

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -127,4 +127,20 @@ test_that("assignment targets of compound lhs are correctly identified", {
   # setters
   expect_lint("setter(badName) <- good_name", msg, linter)
   expect_lint("setter(good_name[[badName]]) <- good_name2", NULL, linter)
+
+  # quotation
+  expect_lint("\"good_name\" <- 42", NULL, linter)
+  expect_lint("\"badName\" <- 42", msg, linter)
+  expect_lint("'good_name' <- 42", NULL, linter)
+  expect_lint("'badName' <- 42", msg, linter)
+  expect_lint("`good_name` <- 42", NULL, linter)
+  expect_lint("`badName` <- 42", msg, linter)
+
+  # subsetting with quotation
+  expect_lint("good_name$\"badName\" <- 42", NULL, linter)
+  expect_lint("good_name$'badName' <- 42", NULL, linter)
+  expect_lint("badName$\"good_name\" <- 42", msg, linter)
+  expect_lint("badName$'good_name' <- 42", msg, linter)
+  expect_lint("`badName`$\"good_name\" <- 42", msg, linter)
+  expect_lint("`badName`$'good_name' <- 42", msg, linter)
 })

--- a/tests/testthat/test-object_name_linter.R
+++ b/tests/testthat/test-object_name_linter.R
@@ -107,11 +107,24 @@ test_that("assignment targets of compound lhs are correctly identified", {
   linter <- object_name_linter()
   msg <- "Variable and function name style should be snake_case or symbols."
 
+  # (recursive) [, $, and [[ subsetting
   expect_lint("good_name[badName] <- badName2", NULL, linter)
   expect_lint("good_name[1L][badName] <- badName2", NULL, linter)
   expect_lint("good_name[[badName]] <- badName2", NULL, linter)
   expect_lint("good_name[[1L]][[badName]] <- badName2", NULL, linter)
   expect_lint("good_name[[fun(badName)]] <- badName2", NULL, linter)
+  expect_lint("good_name[[badName]]$badName2 <- badName3", NULL, linter)
+  expect_lint("good_name$badName[[badName2]][badName3]$badName4 <- badName5", NULL, linter)
+
+  expect_lint("badName[badName] <- badName2", msg, linter)
+  expect_lint("badName[1L][badName] <- badName2", msg, linter)
+  expect_lint("badName[[badName]] <- badName2", msg, linter)
+  expect_lint("badName[[1L]][[badName]] <- badName2", msg, linter)
+  expect_lint("badName[[fun(badName)]] <- badName2", msg, linter)
+  expect_lint("badName[[badName]]$badName2 <- badName3", msg, linter)
+  expect_lint("badName$badName[[badName2]][badName3]$badName4 <- badName5", msg, linter)
+
+  # setters
   expect_lint("setter(badName) <- good_name", msg, linter)
   expect_lint("setter(good_name[[badName]]) <- good_name2", NULL, linter)
 })


### PR DESCRIPTION
- [x] implement fix
- [x] add regression test
- [x] add NEWS bullet

fixes #582