### PR TITLE
Extend branch comparison script

### DIFF
--- a/.dev/compare_branches.R
+++ b/.dev/compare_branches.R
@@ -23,7 +23,7 @@ temp_repo <- file.path(tempdir(), "lintr_repo")
 dir.create(temp_repo)
 file.copy(".", temp_repo, recursive = TRUE)
 message("Executing from copy of repo at ", temp_repo)
-old_ws <- setwd(temp_repo)
+old_wd <- setwd(temp_repo)
 if (!interactive()) {
   .Last <- function() { unlink(temp_repo, recursive = TRUE) }
 }
@@ -277,4 +277,7 @@ if (is_branch) {
 
 write.csv(lints, params$outfile, row.names = FALSE)
 
-if (interactive()) setwd(old_wd)
+if (interactive()) {
+  setwd(old_wd)
+  unlink(temp_repo, recursive = TRUE)
+}

--- a/.dev/compare_branches.R
+++ b/.dev/compare_branches.R
@@ -16,12 +16,14 @@ if (!file.exists("lintr.Rproj")) {
 
 # move to temp repo. this allows multiple executions of this
 #   script simultaneously (otherwise the branch state across
-#   executions will collide)
+#   executions will collide), as well as continuing dev
+#   on the "main" package clone while the script runs (otherwise
+#   all current edits must be checked in before running)
 # named lintr_repo in case this script happens to be run against
 #   a tar of lintr itself...
 temp_repo <- file.path(tempdir(), "lintr_repo")
 dir.create(temp_repo)
-file.copy(".", temp_repo, recursive = TRUE)
+invisible(file.copy(".", temp_repo, recursive = TRUE))
 message("Executing from copy of repo at ", temp_repo)
 old_wd <- setwd(temp_repo)
 if (!interactive()) {

--- a/.dev/compare_branches.R
+++ b/.dev/compare_branches.R
@@ -304,7 +304,17 @@ if (is_branch) {
 } else {
   message("Comparing PR#", pr, " to master")
 }
-message("Comparing output of lint_dir run for the following packages: ", toString(basename(packages)))
+if (length(packages) > 50L) {
+  message(
+    "Comparing output of lint_dir run on many packages; here are 50: ",
+    toString(basename(sample(packages, 50L)))
+  )
+} else {
+  message(
+    "Comparing output of lint_dir run for the following packages: ",
+    toString(basename(packages))
+  )
+}
 
 if (is_branch) {
   lints <- purrr::map_df(linter_names, run_branch_workflow, packages, branch)


### PR DESCRIPTION
Two main new features in this PR:

 1. Copy the repo to a temp dir & run the script from there. That way you can continue editing while running, as well as running multiple comparisons at once
 2. Given how common it is to skip a package due to installation reasons, etc, move to a flow where we try to accumulate `sample_size` successful lints, as opposed `sample_size` total iterations, some percentage of which are just skipped