### PR TITLE
[WIP] Change regex in addin_lint function to also remove comments

### DIFF
--- a/R/addins.R
+++ b/R/addins.R
@@ -10,7 +10,7 @@ addin_lint <- function() {
     config_linters <- NULL
   } else {
     config <- read.dcf(config_file, all = TRUE)
-    config_linters <- gsub("\n", "", config[["linters"]])
+    config_linters <- gsub("(#.*?)?\n", "", config[["linters"]])
   }
   linters <- if (length(config_linters) == 0) {
     message("No configuration found. Using default linters.")

--- a/R/addins.R
+++ b/R/addins.R
@@ -10,7 +10,7 @@ addin_lint <- function() {
     config_linters <- NULL
   } else {
     config <- read.dcf(config_file, all = TRUE)
-    config_linters <- gsub("(#.*?)?\n", "", config[["linters"]])
+    config_linters <- config[["linters"]]
   }
   linters <- if (length(config_linters) == 0) {
     message("No configuration found. Using default linters.")


### PR DESCRIPTION
Fixes #788

This PR updates the regex in the `addin_lint()` function to also remove the comments that can be included in the linters section of a .lintr file.
This is a possible fix for #788.
