### PR TITLE
Fix nolint cache

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -88,18 +88,20 @@ retrieve_lint <- function(cache, expr, linter, lines) {
     mode = "list",
     inherits = FALSE
   )
-  missing_line_number <- FALSE
-  lints[] <- lapply(lints, function(lint) {
-    lint$line_number <- find_new_line(lint$line_number, unname(lint$line), lines)
-    if (is.na(lint$line_number)) {
-      missing_line_number <<- TRUE
+  for (i in seq_along(lints)) {
+    new_line_number <- find_new_line(
+      lints[[i]]$line_number,
+      unname(lints[[i]]$line),
+      lines
+    )
+    if (is.na(new_line_number)) {
+      return(NULL)
+    } else {
+      lints[[i]]$line_number <- new_line_number
     }
-    lint
-  })
-  if (!missing_line_number) {
-    cache_lint(cache, expr, linter, lints)
-    lints
   }
+  cache_lint(cache, expr, linter, lints)
+  lints
 }
 
 has_lint <- function(cache, expr, linter) {

--- a/R/cache.R
+++ b/R/cache.R
@@ -88,12 +88,18 @@ retrieve_lint <- function(cache, expr, linter, lines) {
     mode = "list",
     inherits = FALSE
   )
+  missing_line_number <- FALSE
   lints[] <- lapply(lints, function(lint) {
     lint$line_number <- find_new_line(lint$line_number, unname(lint$line), lines)
+    if (is.na(lint$line_number)) {
+      missing_line_number <<- TRUE
+    }
     lint
   })
-  cache_lint(cache, expr, linter, lints)
-  lints
+  if (!missing_line_number) {
+    cache_lint(cache, expr, linter, lints)
+    lints
+  }
 }
 
 has_lint <- function(cache, expr, linter) {
@@ -117,6 +123,10 @@ digest_content <- function(linters, obj) {
 }
 
 find_new_line <- function(line_number, line, lines) {
+
+  if (is.na(line_number)) {
+    return(NA)
+  }
 
   if (lines[line_number] %==% line) {
     return(line_number)

--- a/R/cache.R
+++ b/R/cache.R
@@ -126,10 +126,6 @@ digest_content <- function(linters, obj) {
 
 find_new_line <- function(line_number, line, lines) {
 
-  if (is.na(line_number)) {
-    return(NA)
-  }
-
   if (lines[line_number] %==% line) {
     return(line_number)
   }

--- a/R/lint.R
+++ b/R/lint.R
@@ -112,11 +112,8 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
       if (is.null(expr_lints)) {
         expr_lints <- flatten_lints(linters[[linter]](expr))
 
-        if (length(expr_lints)) {
-          expr_lints[] <- lapply(expr_lints, function(lint) {
-            lint$linter <- linter
-            lint
-          })
+        for (i in seq_along(expr_lints)) {
+          expr_lints[[i]]$linter <- linter
         }
 
         if (isTRUE(cache)) {

--- a/R/lint.R
+++ b/R/lint.R
@@ -102,14 +102,14 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
 
   for (expr in source_expressions$expressions) {
     for (linter in names(linters)) {
-      lint <- NULL
+      expr_lints <- NULL
       if (isTRUE(cache) && has_lint(lint_cache, expr, linter)) {
         # retrieve_lint() might return NULL if missing line number is encountered.
         # It could be caused by nolint comments.
-        lint <- retrieve_lint(lint_cache, expr, linter, source_expressions$lines)
+        expr_lints <- retrieve_lint(lint_cache, expr, linter, source_expressions$lines)
       }
 
-      if (is.null(lint)) {
+      if (is.null(expr_lints)) {
         expr_lints <- flatten_lints(linters[[linter]](expr))
 
         if (length(expr_lints)) {
@@ -119,13 +119,11 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
           })
         }
 
-        lints[[itr <- itr + 1L]] <- expr_lints
         if (isTRUE(cache)) {
           cache_lint(lint_cache, expr, linter, expr_lints)
         }
-      } else {
-        lints[[itr <- itr + 1L]] <- lint
       }
+      lints[[itr <- itr + 1L]] <- expr_lints
     }
   }
 

--- a/R/lint.R
+++ b/R/lint.R
@@ -102,10 +102,14 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
 
   for (expr in source_expressions$expressions) {
     for (linter in names(linters)) {
+      lint <- NULL
       if (isTRUE(cache) && has_lint(lint_cache, expr, linter)) {
-        lints[[itr <- itr + 1L]] <- retrieve_lint(lint_cache, expr, linter, source_expressions$lines)
+        # retrieve_lint() might return NULL if missing line number is encountered.
+        # It could be caused by nolint comments.
+        lint <- retrieve_lint(lint_cache, expr, linter, source_expressions$lines)
       }
-      else {
+
+      if (is.null(lint)) {
         expr_lints <- flatten_lints(linters[[linter]](expr))
 
         if (length(expr_lints)) {
@@ -119,6 +123,8 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
         if (isTRUE(cache)) {
           cache_lint(lint_cache, expr, linter, expr_lints)
         }
+      } else {
+        lints[[itr <- itr + 1L]] <- lint
       }
     }
   }

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -462,3 +462,20 @@ test_that("cache = TRUE workflow works", {
   l2 <- lint_package(pkg, cache = TRUE)
   expect_identical(l1, l2)
 })
+
+test_that("cache = TRUE works with nolint", {
+  file <- tempfile()
+  on.exit(unlink(file))
+
+  writeLines("1+1\n", file)
+  expect_length(lint(file, cache = TRUE), 1)
+
+  writeLines("1+1 # nolint\n", file)
+  expect_length(lint(file, cache = TRUE), 0)
+
+  writeLines("1+1\n", file)
+  expect_length(lint(file, cache = TRUE), 1)
+
+  writeLines("1+1 # nolint\n", file)
+  expect_length(lint(file, cache = TRUE), 0)
+})

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -464,18 +464,19 @@ test_that("cache = TRUE workflow works", {
 })
 
 test_that("cache = TRUE works with nolint", {
+  linters <- list(infix_spaces_linter())
   file <- tempfile()
   on.exit(unlink(file))
 
   writeLines("1+1\n", file)
-  expect_length(lint(file, cache = TRUE), 1)
+  expect_length(lint(file, linters, cache = TRUE), 1)
 
   writeLines("1+1 # nolint\n", file)
-  expect_length(lint(file, cache = TRUE), 0)
+  expect_length(lint(file, linters, cache = TRUE), 0)
 
   writeLines("1+1\n", file)
-  expect_length(lint(file, cache = TRUE), 1)
+  expect_length(lint(file, linters, cache = TRUE), 1)
 
   writeLines("1+1 # nolint\n", file)
-  expect_length(lint(file, cache = TRUE), 0)
+  expect_length(lint(file, linters, cache = TRUE), 0)
 })


### PR DESCRIPTION
Closes #800 

If `find_new_line()` returns `NA` it means the content no longer matches the line, then the cached lints are dropped.