### PR TITLE
fix test warnings: use pipe_call_linter()

### DIFF
--- a/tests/testthat/test-pipe_call_linter.R
+++ b/tests/testthat/test-pipe_call_linter.R
@@ -1,8 +1,8 @@
 test_that("pipe_call_linter skips allowed usages", {
-  expect_lint("a %>% foo()", NULL, pipe_call_linter)
-  expect_lint("a %>% foo(x)", NULL, pipe_call_linter)
-  expect_lint("b %>% { foo(., ., .) }", NULL, pipe_call_linter)
-  expect_lint("a %>% foo() %>% bar()", NULL, pipe_call_linter)
+  expect_lint("a %>% foo()", NULL, pipe_call_linter())
+  expect_lint("a %>% foo(x)", NULL, pipe_call_linter())
+  expect_lint("b %>% { foo(., ., .) }", NULL, pipe_call_linter())
+  expect_lint("a %>% foo() %>% bar()", NULL, pipe_call_linter())
 
   # ensure it works across lines too
   lines <- trim_some("
@@ -10,11 +10,11 @@ test_that("pipe_call_linter skips allowed usages", {
     foo() %>%
     bar()
   ")
-  expect_lint(lines, NULL, pipe_call_linter)
+  expect_lint(lines, NULL, pipe_call_linter())
 
   # symbol extraction is OK (don't force extract2(), e.g.)
-  expect_lint("a %>% .$y %>% mean()", NULL, pipe_call_linter)
-  
+  expect_lint("a %>% .$y %>% mean()", NULL, pipe_call_linter())
+
   # more complicated expressions don't pick up on nested symbols
   lines <- trim_some("
   x %>% {
@@ -23,26 +23,26 @@ test_that("pipe_call_linter skips allowed usages", {
     my_combination_fun(tmp, bla)
   }
   ")
-  expect_lint(lines, NULL, pipe_call_linter)
+  expect_lint(lines, NULL, pipe_call_linter())
 })
 
 test_that("pipe_call_linter blocks simple disallowed usages", {
   expect_lint(
     "x %>% foo",
     "Use explicit calls in magrittr pipes",
-    pipe_call_linter
+    pipe_call_linter()
   )
 
   expect_lint(
     "x %>% foo() %>% bar",
     "Use explicit calls in magrittr pipes",
-    pipe_call_linter
+    pipe_call_linter()
   )
 
   expect_lint(
     "x %>% foo %>% bar()",
     "Use explicit calls in magrittr pipes",
-    pipe_call_linter
+    pipe_call_linter()
   )
 
   lines <- trim_some("
@@ -53,6 +53,6 @@ test_that("pipe_call_linter blocks simple disallowed usages", {
   expect_lint(
     lines,
     "Use explicit calls in magrittr pipes",
-    pipe_call_linter
+    pipe_call_linter()
   )
 })


### PR DESCRIPTION
fix https://github.com/jimhester/lintr/issues/812 (the lintr-specific warnings at least)

Formerly, tests for the pipe-call linter used unevaluated function name
`pipe_call_linter` and threw warnings when running tests.

These have all been changed to use `pipe_call_linter()`