### PR TITLE
Fix #815 - "error: unexpected input" from unicode character token

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,7 @@
 * `lint_package()` is also stricter about what it considers to be a package -- folders named `DESCRIPTION` are ignored (#702, @michaelchirico)
 * `lint()` now has a new optional argument `text` for supplying a string or lines directly, e.g. if the file is already in memory or linting is being done ad hoc. (#503, @renkun-ken)
 * New `pipe_call_linter()` enforces that all steps of `magrittr` pipelines use explicit calls instead of symbols, e.g. `x %>% mean()` instead of `x %>% mean` (@michaelchirico)
+* `get_source_expressions()` no longer fails if `getParseData()` returns a truncated (invalid) Unicode character as parsed text (#815, #816, @leogama)
 
 # lintr 2.0.1
 

--- a/R/get_source_expressions.R
+++ b/R/get_source_expressions.R
@@ -294,8 +294,8 @@ fix_column_numbers <- function(content) {
     return(NULL)
   }
 
-  text_lengths <- nchar(content$text, "chars")
-  byte_lengths <- nchar(content$text, "bytes")
+  text_lengths <- nchar(content$text[content$terminal], "chars")
+  byte_lengths <- nchar(content$text[content$terminal], "bytes")
   differences <- byte_lengths - text_lengths
 
   to_change <- which(differences > 0L)

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -79,3 +79,12 @@ test_that("Multi-byte characters correct columns", {
     expect_equal(pc[[1L]]$col1[4L], pc[[1L]]$col1[2L] + 4L)
   })
 })
+
+test_that("Multi-byte character truncated by parser is ignored", {
+  tmp <- tempfile()
+  on.exit(unlink(tmp), add = TRUE)
+  writeLines("y <- x \U2013 42", tmp)  # Unicode en-dash
+  content <- expect_error(get_source_expressions(tmp), NA)
+  expect_identical(content$error$message, "unexpected input")
+  expect_identical(content$error$column_number, 8L)
+})

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -85,6 +85,6 @@ test_that("Multi-byte character truncated by parser is ignored", {
   on.exit(unlink(tmp), add = TRUE)
   writeLines("y <- x \U2013 42", tmp)  # Unicode en-dash
   content <- expect_error(get_source_expressions(tmp), NA)
-  expect_identical(content$error$message, "unexpected input")
-  expect_identical(content$error$column_number, 8L)
+  expect_equal(content$error$message, "unexpected input")
+  expect_equal(content$error$column_number, 8L)
 })


### PR DESCRIPTION
Fixes fail obtained when a syntax error interrupts the parsing at a
Unicode character and, as a consequence, the parsed content returned
by `getParseData(source_file)` includes a truncated UTF-8 multibyte
representation of that character (which is invalid). See the GitHub
issue discussion (#815) for details.

The proposed solution merely "coerces" the `getParseData`'s `text`
column to what it is supposed to be according to its documentation.

An alternative would be to actually fix the table before use:
```r
content[!content$terminal, "text"] <- ""
```