### PR TITLE
Add path_prefix option to lint_package for GitHub Actions annotations

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -273,7 +273,8 @@ lint_dir <- function(path = ".", relative_path = TRUE, ..., exclusions = list("r
 #' }
 #' @export
 lint_package <- function(path = ".", relative_path = TRUE, ...,
-                         exclusions = list("R/RcppExports.R"), parse_settings = TRUE) {
+                         exclusions = list("R/RcppExports.R"), parse_settings = TRUE,
+                         path_prefix = "") {
   pkg_path <- find_package(path)
 
   if (is.null(pkg_path)) {
@@ -300,6 +301,9 @@ lint_package <- function(path = ".", relative_path = TRUE, ...,
       lints,
       function(x) {
         x$filename <- re_substitutes(x$filename, rex(path, one_of("/", "\\")), "")
+        if (nzchar(path_prefix)) {
+          x$filename <- file.path(path_prefix, x$filename)
+        }
         x
       }
     )

--- a/R/lint.R
+++ b/R/lint.R
@@ -259,6 +259,8 @@ lint_dir <- function(path = ".", relative_path = TRUE, ..., exclusions = list("r
 #' Apply one or more linters to all of the R files in a package.
 #' @param path the path to the base directory of the package, if \code{NULL},
 #' it will be searched in the parent directories of the current directory.
+#' @param path_prefix a prefix to add to the path of any file found, useful for
+#' packages in subdirectories on github actions.
 #' @inherit lint_file return
 #' @inheritParams lint_dir
 #' @examples

--- a/man/lint_package.Rd
+++ b/man/lint_package.Rd
@@ -9,7 +9,8 @@ lint_package(
   relative_path = TRUE,
   ...,
   exclusions = list("R/RcppExports.R"),
-  parse_settings = TRUE
+  parse_settings = TRUE,
+  path_prefix = ""
 )
 }
 \arguments{
@@ -27,6 +28,9 @@ absolute path.}
 package path.}
 
 \item{parse_settings}{whether to try and parse the settings.}
+
+\item{path_prefix}{a prefix to add to the path of any file found, useful for
+packages in subdirectories on github actions.}
 }
 \value{
 A list of lint objects.

--- a/tests/testthat/test-ci.R
+++ b/tests/testthat/test-ci.R
@@ -12,6 +12,25 @@ test_that("GitHub Actions functionality works", {
   })
 })
 
+test_that("GitHub Actions functionality works in a subdirectory", {
+  # imitate being on GHA whether or not we are
+  withr::with_envvar(c(GITHUB_ACTIONS = "true"), {
+    old <- options(lintr.rstudio_source_markers = FALSE)
+    on.exit(options(old), add = TRUE)
+
+    read_settings(NULL)
+    pkg_path <- test_path(file.path("dummy_packages", "assignmentLinter"))
+    l <- lint_package(
+      pkg_path, linters = list(assignment_linter()),
+      parse_settings = FALSE, path_prefix = file.path("dummy_packages", "assignmentLinter")
+    )
+    expect_output(
+      print(l),
+      paste0("::warning file=dummy_packages/assignmentLinter/R/abc\\.R")
+    )
+  })
+})
+
 test_that("Printing works for Travis", {
   withr::with_envvar(c(GITHUB_ACTIONS = "false", TRAVIS_REPO_SLUG = "test/repo", LINTR_COMMENT_BOT = "true"), {
     old <- options(lintr.rstudio_source_markers = FALSE)


### PR DESCRIPTION
In order to get GitHub annotations to show up on a PR inline in the code, the annotation path must be relative to the repository root rather than relative to the package root. For most R packages, the package root is the same as the GitHub root, but for packages that use a subdirectory (e.g. https://github.com/apache/arrow in the r/ subdirectory) the annotations don't display without adding a prefix like this.

This PR doesn't change the default case, but adds an argument to `lint_package()` that allows someone to specify the correct prefix.