### PR TITLE
fix undesirable_function_linter when linted expression is found late in file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,7 +70,7 @@
   files in your project. Override the default in the `encoding` setting of lintr. (#752, #782, @AshesITR)
 * New default linter `paren_body_linter()` checks that there is a space between right parenthesis and a body 
   expression. (#809, #830, @kpagacz)
-* `undesirable_function_linter` no longer lints `library` and `require` calls attaching a package with an undesired name, e.g. `library(foo)` (#814, @kpagacz)
+* `undesirable_function_linter` no longer lints `library` and `require` calls attaching a package with an undesired name, e.g. `library(foo)` (#814, @kpagacz and @michaelchirico)
 * New linter `duplicate_argument_linter()` checks that there are no duplicate arguments supplied to
 function calls. (#850, #851, @renkun-ken)
 * Several optional `Imported` packages have become `Suggested` dependencies: `httr`, `testthat`, and `rstudioapi`. This should allow snappier CI builds for usages not relying on some more "peripheral" features of the package.

--- a/R/undesirable_function_linter.R
+++ b/R/undesirable_function_linter.R
@@ -19,7 +19,7 @@ undesirable_function_linter <- function(fun = default_undesirable_functions,
     }
 
     xpath <- sprintf(
-      "//expr[*[(%s) and (%s)] and not(preceding-sibling::expr[SYMBOL_FUNCTION_CALL[%s]])]",
+      "//*[(%s) and (%s) and not(parent::expr/preceding-sibling::expr[SYMBOL_FUNCTION_CALL[%s]])]",
       paste0("self::", tokens, collapse = " or "),
       xp_text_in_table(names(fun)),
       xp_text_in_table(c("library", "require"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -199,6 +199,9 @@ unescape <- function(str, q="`") {
   str
 }
 
+# like `text() %in% table`, translated to XPath 1.0
+xp_text_in_table <- function(table) paste("text() = ", sQuote(table, "'"), collapse = " or ")
+
 # convert an XML match into a Lint
 xml_nodes_to_lint <- function(xml, source_file, message,
                               type = c("style", "warning", "error"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -200,7 +200,7 @@ unescape <- function(str, q="`") {
 }
 
 # like `text() %in% table`, translated to XPath 1.0
-xp_text_in_table <- function(table) paste("text() = ", sQuote(table, "'"), collapse = " or ")
+xp_text_in_table <- function(table) paste("text() = ", quote_wrap(table, "'"), collapse = " or ")
 
 # convert an XML match into a Lint
 xml_nodes_to_lint <- function(xml, source_file, message,

--- a/tests/testthat/test-undesirable_function_linter.R
+++ b/tests/testthat/test-undesirable_function_linter.R
@@ -37,3 +37,9 @@ test_that("undesirable_function_linter doesn't lint library and require calls", 
   linter <- undesirable_function_linter(fun = c("foo" = NA, "bar" = NA), symbol_is_undesirable = FALSE)
   expect_lint("library(foo)", NULL, linter)
 })
+
+# regression test for #866
+test_that("Line numbers are extracted correctly", {
+  lines <- c(rep(letters, 10L), "tmp <- tempdir()")
+  expect_lint(paste(lines, collapse = "\n"), "undesirable", undesirable_function_linter(c(tempdir = NA)))
+})


### PR DESCRIPTION
Closes #866

The issue is that `source_file$lines[[line]]` relies on `source_file$lines` having the line numbers as names, not as integers. So `source_file$lines[['111']]` (correct) is not the same as `source_file$lines[[111L]]` (on HEAD).

This only shows up if the expression at fault comes later in the file (or perhaps just at the 2nd expression of a 2-line file); that's reflected in the new test.

I also tidied up the xpath a bit, I think it's clearer to understand now.

I'll file a follow-up PR using the new helper a bit more broadly.