### PR TITLE
docs(cyclocomp_linter.R): updated the default parameter value

### DIFF
--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -1,7 +1,7 @@
 #' @describeIn linters Check for overly complicated expressions. See
 #'   \code{\link[cyclocomp]{cyclocomp}}.
 #' @param complexity_limit expressions with a cyclomatic complexity higher than
-#'   this are linted, defaults to 25. See \code{\link[cyclocomp]{cyclocomp}}.
+#'   this are linted, defaults to 15. See \code{\link[cyclocomp]{cyclocomp}}.
 #' @importFrom cyclocomp cyclocomp
 #' @export
 cyclocomp_linter <- function(complexity_limit = 15L) {

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -41,9 +41,9 @@
 #' @export
 expect_lint <- function(content, checks, ..., file = NULL, language = "en") {
   if (!requireNamespace("testthat", quietly = TRUE)) {
-    stop(
+    stop( # nocov start
       "'expect_lint' is designed to work within the 'testthat' testing framework, but 'testthat' is not installed."
-    ) # nocov
+    ) # nocov end
   }
   old_lang <- set_lang(language)
   on.exit(reset_lang(old_lang))

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -41,7 +41,9 @@
 #' @export
 expect_lint <- function(content, checks, ..., file = NULL, language = "en") {
   if (!requireNamespace("testthat", quietly = TRUE)) {
-    stop("'expect_lint' is designed to work within the 'testthat' testing framework, but 'testthat' is not installed.") # nocov
+    stop(
+      "'expect_lint' is designed to work within the 'testthat' testing framework, but 'testthat' is not installed."
+    ) # nocov
   }
   old_lang <- set_lang(language)
   on.exit(reset_lang(old_lang))

--- a/man/linters.Rd
+++ b/man/linters.Rd
@@ -155,7 +155,7 @@ on the same line.}
 \item{todo}{Vector of strings that identify TODO comments.}
 
 \item{complexity_limit}{expressions with a cyclomatic complexity higher than
-this are linted, defaults to 25. See \code{\link[cyclocomp]{cyclocomp}}.}
+this are linted, defaults to 15. See \code{\link[cyclocomp]{cyclocomp}}.}
 
 \item{styles}{A subset of
 \Sexpr[stage=render, results=rd]{lintr:::regexes_rd}. A name should


### PR DESCRIPTION
* updated the default parameter value of `cyclocomp_linter` in the documentation from 25 to 15. Now it matches the default value in the function definition.

Closes #853