### PR TITLE
Extend assignment_operator to optionally allow '=' assignments

### DIFF
--- a/R/assignment_linter.R
+++ b/R/assignment_linter.R
@@ -7,6 +7,9 @@
 #' @param allow_right_assign Logical, default `FALSE`. If `TRUE`, `->` and `->>` are allowed.
 #' @param allow_trailing Logical, default `TRUE`. If `FALSE` then assignments aren't allowed at end of lines.
 #' @param allow_pipe_assign Logical, default `FALSE`. If `TRUE`, magrittr's `%<>%` assignment is allowed.
+#' @param top_level_operator Character, default `"<-"`, matching the style guide recommendation for assignments with
+#'   `<-`. When `"="`, all top-level assignments must be done with `=`; when `"any"`, there is no enforcement of
+#'   top-level assignment operator.
 #'
 #' @examples
 #' # will produce lints
@@ -25,6 +28,11 @@
 #' lint(
 #'   text = "x %<>% as.character()",
 #'   linters = assignment_linter()
+#' )
+#'
+#' lint(
+#'   text = "x <- 1",
+#'   linters = assignment_linter(top_level_operator = "=")
 #' )
 #'
 #' # okay
@@ -64,6 +72,11 @@
 #'   linters = assignment_linter(allow_pipe_assign = TRUE)
 #' )
 #'
+#' lint(
+#'   text = "x = 1",
+#'   linters = assignment_linter(top_level_operator = "=")
+#' )
+#'
 #' @evalRd rd_tags("assignment_linter")
 #' @seealso
 #' - [linters] for a complete list of linters available in lintr.
@@ -73,7 +86,10 @@
 assignment_linter <- function(allow_cascading_assign = TRUE,
                               allow_right_assign = FALSE,
                               allow_trailing = TRUE,
-                              allow_pipe_assign = FALSE) {
+                              allow_pipe_assign = FALSE,
+                              top_level_operator = c("<-", "=", "any")) {
+  top_level_operator <- match.arg(top_level_operator)
+
   trailing_assign_xpath <- paste(
     collapse = " | ",
     c(

--- a/tests/testthat/test-assignment_linter.R
+++ b/tests/testthat/test-assignment_linter.R
@@ -192,3 +192,61 @@ test_that("multiple lints throw correct messages", {
     assignment_linter(allow_cascading_assign = FALSE)
   )
 })
+
+test_that("assignment operator can be toggled", {
+  eq_linter <- assignment_linter(top_level_operator = "=")
+  any_linter <- assignment_linter(top_level_operator = "any")
+
+  expect_lint("a = 1", NULL, eq_linter())
+  expect_lint("a = 1", NULL, any_linter())
+
+  expect_lint("a <- 1", "xxx", eq_linter())
+  expect_lint("a <- 1", NULL, any_linter())
+
+  expect_lint("a = 1; b <- 2", "xxx", eq_linter())
+  expect_lint("a = 1; b <- 2", NULL, any_linter())
+
+  expect_lint(
+    trim_some("
+      foo = function() {
+        a = 1
+      }
+    "),
+    NULL,
+    eq_linter()
+  )
+  expect_lint(
+    trim_some("
+      foo = function() {
+        a = 1
+      }
+    "),
+    NULL,
+    any_linter()
+  )
+
+  expect_lint(
+    trim_some("
+      foo = function() {
+        a <- 1
+      }
+    "),
+    NULL,
+    eq_linter()
+  )
+  expect_lint(
+    trim_some("
+      foo = function() {
+        a <- 1
+      }
+    "),
+    NULL,
+    any_linter()
+  )
+
+  expect_lint("if ({a = TRUE}) 1", NULL, eq_linter())
+  expect_lint("if ({a = TRUE}) 1", NULL, any_linter())
+
+  expect_lint("if ({a <- TRUE}) 1", NULL, eq_linter())
+  expect_lint("if ({a <- TRUE}) 1", NULL, any_linter())
+})


### PR DESCRIPTION
Closes #2441. Tests are partially copied from #2521 -- for implementation I'm starting from scratch rather than trying to re-work it based on the discussion there. Thanks @J-Moravec for getting things started & the fruitful discussion!

Pausing here for, well, even more discussion :)

I'm getting hung up on the interaction of the proposed argument with the other arguments, particularly `allow_right_assign` and `allow_pipe_assign`.

If we have `(allow_right_assign=FALSE, top_level_operator="any")`, that does make `x -> 2` a bit ambiguous, right?

I can think of two options:

 1. Subsume the other options into this new one by allowing `top_level_operator = c("<-", "->", "%<>%")` to be equivalent to the current `(allow_right_assign=TRUE, allow_pipe_assign=TRUE)`. That looks pretty transparent to me, but presents some back-compatibility issues.
 2. Ditch `any` in favor of `either`, i.e. _either_ `<-` or `=`.

WDYT @IndrajeetPatil @AshesITR?