### PR TITLE
Remove vestiges of R<4 support

### DIFF
--- a/tests/testthat/test-absolute_path_linter.R
+++ b/tests/testthat/test-absolute_path_linter.R
@@ -140,11 +140,11 @@ test_that("returns the correct linting", {
     encodeString("blah\\file.txt")
   )
   for (path in non_absolute_path_strings) {
-    expect_lint(single_quote(path), NULL, linter)
-    expect_lint(double_quote(path), NULL, linter)
+    expect_no_lint(single_quote(path), linter)
+    expect_no_lint(double_quote(path), linter)
   }
 
-  expect_lint("\"'/'\"", NULL, linter) # nested quotes
+  expect_no_lint("\"'/'\"", linter) # nested quotes
 
   absolute_path_strings <- c(
     "/",
@@ -171,14 +171,13 @@ test_that("returns the correct linting", {
     "/as:df/bar"
   )
   for (path in unlikely_path_strings) {
-    expect_lint(single_quote(path), NULL, linter)
-    expect_lint(double_quote(path), NULL, linter)
+    expect_no_lint(single_quote(path), linter)
+    expect_no_lint(double_quote(path), linter)
   }
 })
 
 test_that("raw strings are handled correctly", {
-  skip_if_not_r_version("4.0.0")
-  expect_lint('R"(./blah)"', NULL, absolute_path_linter(lax = FALSE))
+  expect_no_lint('R"(./blah)"', absolute_path_linter(lax = FALSE))
   expect_lint(
     "R'--[/blah/file.txt]--'",
     rex::rex("Do not use absolute paths."),

--- a/tests/testthat/test-condition_message_linter.R
+++ b/tests/testthat/test-condition_message_linter.R
@@ -1,18 +1,18 @@
 test_that("condition_message_linter skips allowed usages", {
   linter <- condition_message_linter()
 
-  expect_lint("stop('a string', 'another')", NULL, linter)
-  expect_lint("warning('a string', 'another')", NULL, linter)
-  expect_lint("message('a string', 'another')", NULL, linter)
+  expect_no_lint("stop('a string', 'another')", linter)
+  expect_no_lint("warning('a string', 'another')", linter)
+  expect_no_lint("message('a string', 'another')", linter)
   # extracted calls likely don't obey base::stop() semantics
-  expect_lint("ctx$stop(paste('a', 'b'))", NULL, linter)
-  expect_lint("ctx@stop(paste('a', 'b'))", NULL, linter)
+  expect_no_lint("ctx$stop(paste('a', 'b'))", linter)
+  expect_no_lint("ctx@stop(paste('a', 'b'))", linter)
 
   # sprintf is OK -- gettextf() enforcement is left to other linters
-  expect_lint("stop(sprintf('A %s!', 'string'))", NULL, linter)
+  expect_no_lint("stop(sprintf('A %s!', 'string'))", linter)
 
   # get multiple sep= in one expression
-  expect_lint(
+  expect_no_lint(
     trim_some("
       tryCatch(
         foo(x),
@@ -20,7 +20,6 @@ test_that("condition_message_linter skips allowed usages", {
         warning = function(w) warning(paste(a, b, sep = '--')),
       )
     "),
-    NULL,
     linter
   )
 })
@@ -28,9 +27,8 @@ test_that("condition_message_linter skips allowed usages", {
 skip_if_not_installed("tibble")
 patrick::with_parameters_test_that(
   "paste/paste0 allowed by condition_message_linter when using other seps and/or collapse",
-  expect_lint(
+  expect_no_lint(
     sprintf("%s(%s(x, %s = '%s'))", condition, fun, parameter, arg),
-    NULL,
     condition_message_linter()
   ),
   .cases = tibble::tribble(
@@ -48,36 +46,27 @@ patrick::with_parameters_test_that(
 )
 
 test_that("condition_message_linter blocks simple disallowed usages", {
-  expect_lint(
-    "stop(paste('a string', 'another'))",
-    rex::rex("Don't use paste to build stop strings."),
-    condition_message_linter()
-  )
+  linter <- condition_message_linter()
+  lint_msg_paste_stop <- rex::rex("Don't use paste to build stop strings.")
+
+  expect_lint("stop(paste('a string', 'another'))", lint_msg_paste_stop, linter)
 
   expect_lint(
     "warning(paste0('a string ', 'another'))",
     rex::rex("Don't use paste0 to build warning strings."),
-    condition_message_linter()
+    linter
   )
 
   # `sep` argument allowed, but only if it is different from default
-  expect_lint(
-    "stop(paste(x, sep = ' '))",
-    rex::rex("Don't use paste to build stop strings."),
-    condition_message_linter()
-  )
+  expect_lint("stop(paste(x, sep = ' '))", lint_msg_paste_stop, linter)
 
   # not thrown off by named arguments
-  expect_lint(
-    "stop(paste('a', 'b'), call. = FALSE)",
-    rex::rex("Don't use paste to build stop strings."),
-    condition_message_linter()
-  )
+  expect_lint("stop(paste('a', 'b'), call. = FALSE)", lint_msg_paste_stop, linter)
 
   expect_lint(
     "warning(paste0('a', 'b'), immediate. = TRUE)",
     rex::rex("Don't use paste0 to build warning strings."),
-    condition_message_linter()
+    linter
   )
 
   expect_lint(
@@ -88,8 +77,8 @@ test_that("condition_message_linter blocks simple disallowed usages", {
         warning = function(w) warning(paste(a, b, sep = '--')),
       )
     "),
-    rex::rex("Don't use paste to build stop strings."),
-    condition_message_linter()
+    lint_msg_paste_stop,
+    linter
   )
 
   # one with no sep, one with linted sep
@@ -102,10 +91,10 @@ test_that("condition_message_linter blocks simple disallowed usages", {
       )
     "),
     list(
-      list(message = rex::rex("Don't use paste to build stop strings."), line_number = 3L),
-      list(message = rex::rex("Don't use paste to build warning strings"), line_number = 4L)
+      list(lint_msg_paste_stop, line_number = 3L),
+      list(rex::rex("Don't use paste to build warning strings"), line_number = 4L)
     ),
-    condition_message_linter()
+    linter
   )
 })
 
@@ -123,18 +112,12 @@ test_that("packageStartupMessage usages are also matched", {
   )
 })
 
-test_that("R>=4.0.0 raw strings are handled", {
-  skip_if_not_r_version("4.0.0")
-  expect_lint(
-    "warning(paste(a, b, sep = R'( )'))",
-    rex::rex("Don't use paste to build warning strings."),
-    condition_message_linter()
-  )
-  expect_lint(
-    "warning(paste(a, b, sep = R'---[ ]---'))",
-    rex::rex("Don't use paste to build warning strings."),
-    condition_message_linter()
-  )
+test_that("raw strings are handled correctly", {
+  linter <- condition_message_linter()
+  lint_msg <- rex::rex("Don't use paste to build warning strings.")
+
+  expect_lint("warning(paste(a, b, sep = R'( )'))", lint_msg, linter)
+  expect_lint("warning(paste(a, b, sep = R'---[ ]---'))", lint_msg, linter)
 })
 
 test_that("message vectorization works", {

--- a/tests/testthat/test-get_source_expressions.R
+++ b/tests/testthat/test-get_source_expressions.R
@@ -137,9 +137,6 @@ test_that("Warns if encoding is misspecified", {
 })
 
 test_that("Can extract line number from parser errors", {
-  skip_if_not_r_version("4.0.0")
-
-  # malformed raw string literal at line 2
   with_content_to_parse(
     trim_some('
       "ok"
@@ -151,7 +148,6 @@ test_that("Can extract line number from parser errors", {
     }
   )
 
-  # invalid \u{xxxx} sequence (line 3)
   with_content_to_parse(
     trim_some('
       ok
@@ -164,7 +160,6 @@ test_that("Can extract line number from parser errors", {
     }
   )
 
-  # invalid \u{xxxx} sequence (line 4)
   with_content_to_parse(
     trim_some('
       ok
@@ -178,7 +173,6 @@ test_that("Can extract line number from parser errors", {
     }
   )
 
-  # repeated formal argument 'a' on line 1
   with_content_to_parse("function(a, a) {}", {
     expect_identical(error$message, "Repeated formal argument 'a'.")
     expect_identical(error$line_number, 1L)

--- a/tests/testthat/test-is_numeric_linter.R
+++ b/tests/testthat/test-is_numeric_linter.R
@@ -1,21 +1,21 @@
 test_that("is_numeric_linter skips allowed usages involving ||", {
   linter <- is_numeric_linter()
 
-  expect_lint("is.numeric(x) || is.integer(y)", NULL, linter)
+  expect_no_lint("is.numeric(x) || is.integer(y)", linter)
   # x is used, but not identically
-  expect_lint("is.numeric(x) || is.integer(foo(x))", NULL, linter)
+  expect_no_lint("is.numeric(x) || is.integer(foo(x))", linter)
   # not totally crazy, e.g. if input accepts a vector or a list
-  expect_lint("is.numeric(x) || is.integer(x[[1]])", NULL, linter)
+  expect_no_lint("is.numeric(x) || is.integer(x[[1]])", linter)
 })
 
 test_that("is_numeric_linter skips allowed usages involving %in%", {
   linter <- is_numeric_linter()
 
   # false positives for class(x) %in% c('integer', 'numeric') style
-  expect_lint("class(x) %in% 1:10", NULL, linter)
-  expect_lint("class(x) %in% 'numeric'", NULL, linter)
-  expect_lint("class(x) %in% c('numeric', 'integer', 'factor')", NULL, linter)
-  expect_lint("class(x) %in% c('numeric', 'integer', y)", NULL, linter)
+  expect_no_lint("class(x) %in% 1:10", linter)
+  expect_no_lint("class(x) %in% 'numeric'", linter)
+  expect_no_lint("class(x) %in% c('numeric', 'integer', 'factor')", linter)
+  expect_no_lint("class(x) %in% c('numeric', 'integer', y)", linter)
 })
 
 test_that("is_numeric_linter blocks disallowed usages involving ||", {
@@ -55,13 +55,11 @@ test_that("is_numeric_linter blocks disallowed usages involving %in%", {
 })
 
 test_that("raw strings are handled properly when testing in class", {
-  skip_if_not_r_version("4.0.0")
-
   linter <- is_numeric_linter()
   lint_msg <- rex::rex('Use is.numeric(x) instead of class(x) %in% c("integer", "numeric")')
 
-  expect_lint("class(x) %in% c(R'(numeric)', 'integer', 'factor')", NULL, linter)
-  expect_lint("class(x) %in% c('numeric', R'--(integer)--', y)", NULL, linter)
+  expect_no_lint("class(x) %in% c(R'(numeric)', 'integer', 'factor')", linter)
+  expect_no_lint("class(x) %in% c('numeric', R'--(integer)--', y)", linter)
 
   expect_lint("class(x) %in% c(R'(integer)', 'numeric')", lint_msg, linter)
   expect_lint('class(x) %in% c("numeric", R"--[integer]--")', lint_msg, linter)

--- a/tests/testthat/test-make_linter_from_xpath.R
+++ b/tests/testthat/test-make_linter_from_xpath.R
@@ -21,12 +21,12 @@ test_that("input validation works", {
     fixed = TRUE
   )
 
-  err_msg <- if (getRversion() < "4.0.0") "is.character(xpath)" else "xpath should be a character string"
+  err_msg <- "xpath should be a character string"
   expect_error(make_linter_from_xpath(FALSE), err_msg, fixed = TRUE)
   expect_error(make_linter_from_xpath(letters), err_msg, fixed = TRUE)
   expect_error(make_linter_from_xpath(NA_character_), err_msg, fixed = TRUE)
   expect_error(make_linter_from_xpath(character()), err_msg, fixed = TRUE)
 
-  err_msg <- if (getRversion() < "4.0.0") "!missing(lint_message)" else "lint_message is required"
+  err_msg <- "lint_message is required"
   expect_error(make_linter_from_xpath(""), err_msg, fixed = TRUE)
 })

--- a/tests/testthat/test-paste_linter.R
+++ b/tests/testthat/test-paste_linter.R
@@ -1,13 +1,13 @@
 test_that("paste_linter skips allowed usages for sep=''", {
   linter <- paste_linter()
 
-  expect_lint("paste('a', 'b', 'c')", NULL, linter)
-  expect_lint("paste('a', 'b', 'c', sep = ',')", NULL, linter)
-  expect_lint("paste('a', 'b', collapse = '')", NULL, linter)
-  expect_lint("cat(paste('a', 'b'), sep = '')", NULL, linter)
-  expect_lint("sep <- ''; paste('a', sep)", NULL, linter)
-  expect_lint("paste(sep = ',', '', 'a')", NULL, linter)
-  expect_lint("paste0('a', 'b', 'c')", NULL, linter)
+  expect_no_lint("paste('a', 'b', 'c')", linter)
+  expect_no_lint("paste('a', 'b', 'c', sep = ',')", linter)
+  expect_no_lint("paste('a', 'b', collapse = '')", linter)
+  expect_no_lint("cat(paste('a', 'b'), sep = '')", linter)
+  expect_no_lint("sep <- ''; paste('a', sep)", linter)
+  expect_no_lint("paste(sep = ',', '', 'a')", linter)
+  expect_no_lint("paste0('a', 'b', 'c')", linter)
 })
 
 test_that("paste_linter blocks simple disallowed usages for sep=''", {
@@ -27,23 +27,23 @@ test_that("paste_linter blocks simple disallowed usages for sep=''", {
 test_that("paste_linter skips allowed usages for collapse=', '", {
   linter <- paste_linter()
 
-  expect_lint("paste('a', 'b', 'c')", NULL, linter)
-  expect_lint("paste(x, sep = ', ')", NULL, linter)
-  expect_lint("paste(x, collapse = ',')", NULL, linter)
-  expect_lint("paste(foo(x), collapse = '/')", NULL, linter)
+  expect_no_lint("paste('a', 'b', 'c')", linter)
+  expect_no_lint("paste(x, sep = ', ')", linter)
+  expect_no_lint("paste(x, collapse = ',')", linter)
+  expect_no_lint("paste(foo(x), collapse = '/')", linter)
   # harder to catch statically
-  expect_lint("collapse <- ', '; paste(x, collapse = collapse)", NULL, linter)
+  expect_no_lint("collapse <- ', '; paste(x, collapse = collapse)", linter)
 
   # paste(..., sep=sep, collapse=", ") is not a trivial swap to toString
-  expect_lint("paste(x, y, sep = '.', collapse = ', ')", NULL, linter)
+  expect_no_lint("paste(x, y, sep = '.', collapse = ', ')", linter)
   # any call involving ...length() > 1 will implicitly use the default sep
-  expect_lint("paste(x, y, collapse = ', ')", NULL, linter)
-  expect_lint("paste0(x, y, collapse = ', ')", NULL, linter)
+  expect_no_lint("paste(x, y, collapse = ', ')", linter)
+  expect_no_lint("paste0(x, y, collapse = ', ')", linter)
 
-  expect_lint("toString(x)", NULL, linter)
+  expect_no_lint("toString(x)", linter)
 
   # string match of ", " is OK -- lint only _exact_ match
-  expect_lint('paste(x, collapse = ", \n")', NULL, linter)
+  expect_no_lint('paste(x, collapse = ", \n")', linter)
 })
 
 test_that("paste_linter blocks simple disallowed usages for collapse=', '", {
@@ -55,22 +55,21 @@ test_that("paste_linter blocks simple disallowed usages for collapse=', '", {
 })
 
 test_that("paste_linter respects non-default arguments", {
-  expect_lint("paste(sep = '', 'a', 'b')", NULL, paste_linter(allow_empty_sep = TRUE))
-  expect_lint("paste('a', 'b', sep = '')", NULL, paste_linter(allow_empty_sep = TRUE))
+  expect_no_lint("paste(sep = '', 'a', 'b')", paste_linter(allow_empty_sep = TRUE))
+  expect_no_lint("paste('a', 'b', sep = '')", paste_linter(allow_empty_sep = TRUE))
 
-  expect_lint("paste(collapse = ', ', x)", NULL, paste_linter(allow_to_string = TRUE))
+  expect_no_lint("paste(collapse = ', ', x)", paste_linter(allow_to_string = TRUE))
 })
 
 test_that("paste_linter works for raw strings", {
-  skip_if_not_r_version("4.0.0")
-  expect_lint("paste(a, b, sep = R'(xyz)')", NULL, paste_linter())
+  expect_no_lint("paste(a, b, sep = R'(xyz)')", paste_linter())
   expect_lint(
     'paste(a, b, sep = R"---[]---")',
     rex::rex('paste0(...) is better than paste(..., sep = "").'),
     paste_linter()
   )
 
-  expect_lint("paste(x, collapse = R'(,,)')", NULL, paste_linter())
+  expect_no_lint("paste(x, collapse = R'(,,)')", paste_linter())
   expect_lint(
     'paste(c(a, b, c), collapse = R"-{, }-")',
     rex::rex('toString(.) is more expressive than paste(., collapse = ", ")'),
@@ -89,14 +88,14 @@ test_that("paste_linter catches use of paste0 with sep=", {
 test_that("paste_linter skips allowed usages for strrep()", {
   linter <- paste_linter()
 
-  expect_lint("paste(x, collapse = '')", NULL, linter)
-  expect_lint("paste(rep('*', 10), collapse = '+')", NULL, linter)
-  expect_lint("paste(rep(c('a', 'b'), 2), collapse = '')", NULL, linter)
-  expect_lint("paste0(rep('a', 2), 'b', collapse = '')", NULL, linter)
+  expect_no_lint("paste(x, collapse = '')", linter)
+  expect_no_lint("paste(rep('*', 10), collapse = '+')", linter)
+  expect_no_lint("paste(rep(c('a', 'b'), 2), collapse = '')", linter)
+  expect_no_lint("paste0(rep('a', 2), 'b', collapse = '')", linter)
   # no collapse
-  expect_lint("paste(rep('*', 10))", NULL, linter)
+  expect_no_lint("paste(rep('*', 10))", linter)
   # combined before aggregating
-  expect_lint("paste(rep('*', 10), rep('x', 10), collapse = '')", NULL, linter)
+  expect_no_lint("paste(rep('*', 10), rep('x', 10), collapse = '')", linter)
 })
 
 test_that("paste_linter blocks simple disallowed usages", {
@@ -110,20 +109,20 @@ test_that("paste_linter blocks simple disallowed usages", {
 test_that("paste_linter skips allowed usages for file paths", {
   linter <- paste_linter()
 
-  expect_lint("paste('a', 'b', 'c')", NULL, linter)
-  expect_lint("paste('a', 'b', 'c', sep = ',')", NULL, linter)
-  expect_lint("paste('a', 'b', collapse = '/')", NULL, linter)
-  expect_lint("cat(paste('a', 'b'), sep = '/')", NULL, linter)
-  expect_lint("sep <- '/'; paste('a', sep)", NULL, linter)
-  expect_lint("paste(sep = ',', '/', 'a')", NULL, linter)
+  expect_no_lint("paste('a', 'b', 'c')", linter)
+  expect_no_lint("paste('a', 'b', 'c', sep = ',')", linter)
+  expect_no_lint("paste('a', 'b', collapse = '/')", linter)
+  expect_no_lint("cat(paste('a', 'b'), sep = '/')", linter)
+  expect_no_lint("sep <- '/'; paste('a', sep)", linter)
+  expect_no_lint("paste(sep = ',', '/', 'a')", linter)
 
   # paste(..., sep='/', collapse=collapse) is not a trivial swap to file.path
-  expect_lint("paste(x, y, sep = '/', collapse = ':')", NULL, linter)
+  expect_no_lint("paste(x, y, sep = '/', collapse = ':')", linter)
 
-  expect_lint("file.path('a', 'b', 'c')", NULL, linter)
+  expect_no_lint("file.path('a', 'b', 'c')", linter)
 
   # testing the sep starts with / is not enough
-  expect_lint("paste('a', 'b', sep = '//')", NULL, linter)
+  expect_no_lint("paste('a', 'b', sep = '//')", linter)
 })
 
 test_that("paste_linter blocks simple disallowed usages for file paths", {
@@ -137,18 +136,18 @@ test_that("paste_linter blocks simple disallowed usages for file paths", {
 test_that("paste_linter ignores non-path cases with paste0", {
   linter <- paste_linter()
 
-  expect_lint("paste0(x, y)", NULL, linter)
-  expect_lint("paste0('abc', 'def')", NULL, linter)
-  expect_lint("paste0('/abc', 'def/')", NULL, linter)
-  expect_lint("paste0(x, 'def/')", NULL, linter)
-  expect_lint("paste0('/abc', y)", NULL, linter)
-  expect_lint("paste0(foo(x), y)", NULL, linter)
-  expect_lint("paste0(foo(x), 'def')", NULL, linter)
+  expect_no_lint("paste0(x, y)", linter)
+  expect_no_lint("paste0('abc', 'def')", linter)
+  expect_no_lint("paste0('/abc', 'def/')", linter)
+  expect_no_lint("paste0(x, 'def/')", linter)
+  expect_no_lint("paste0('/abc', y)", linter)
+  expect_no_lint("paste0(foo(x), y)", linter)
+  expect_no_lint("paste0(foo(x), 'def')", linter)
 
   # these might be a different lint (as.character instead, e.g.) but not here
-  expect_lint("paste0(x)", NULL, linter)
-  expect_lint("paste0('a')", NULL, linter)
-  expect_lint("paste0('a', 1)", NULL, linter)
+  expect_no_lint("paste0(x)", linter)
+  expect_no_lint("paste0('a')", linter)
+  expect_no_lint("paste0('a', 1)", linter)
 })
 
 test_that("paste_linter detects paths built with '/' and paste0", {
@@ -164,10 +163,10 @@ test_that("paste_linter detects paths built with '/' and paste0", {
 test_that("paste_linter skips initial/terminal '/' and repeated '/' for paths", {
   linter <- paste_linter()
 
-  expect_lint("paste0('/', x)", NULL, linter)
-  expect_lint("paste0(x, '/')", NULL, linter)
-  expect_lint("paste0(x, '//hey/', y)", NULL, linter)
-  expect_lint("paste0(x, '/hey//', y)", NULL, linter)
+  expect_no_lint("paste0('/', x)", linter)
+  expect_no_lint("paste0(x, '/')", linter)
+  expect_no_lint("paste0(x, '//hey/', y)", linter)
+  expect_no_lint("paste0(x, '/hey//', y)", linter)
 })
 
 test_that("paste_linter doesn't skip all initial/terminal '/' for paths", {
@@ -213,26 +212,24 @@ test_that("multiple path lints are generated correctly", {
 })
 
 test_that("allow_file_path argument works", {
-  expect_lint("paste(x, y, sep = '/')", NULL, paste_linter(allow_file_path = "always"))
+  expect_no_lint("paste(x, y, sep = '/')", paste_linter(allow_file_path = "always"))
 })
 
 test_that("URLs are ignored by default, linted optionally", {
   linter <- paste_linter()
   linter_url <- paste_linter(allow_file_path = "never")
 
-  expect_lint("paste0('http://site.com/', x)", NULL, linter)
+  expect_no_lint("paste0('http://site.com/', x)", linter)
   expect_lint("paste0('http://site.com/', x)", rex::rex("Construct file paths with file.path(...)"), linter_url)
 })
 
 test_that("raw strings are detected in file path logic", {
-  skip_if_not_r_version("4.0.0")
-
   linter <- paste_linter()
   lint_msg <- rex::rex("Construct file paths with file.path(...) instead of ")
 
-  expect_lint("paste0(x, R'{abc}', y)", NULL, linter)
+  expect_no_lint("paste0(x, R'{abc}', y)", linter)
   expect_lint("paste0(x, R'{/abc/}', y)", lint_msg, linter)
-  expect_lint("paste(x, y, sep = R'{//}')", NULL, linter)
+  expect_no_lint("paste(x, y, sep = R'{//}')", linter)
   expect_lint("paste(x, y, sep = R'{/}')", lint_msg, linter)
 })
 
@@ -240,10 +237,10 @@ test_that("paste0(collapse=...) is caught", {
   linter <- paste_linter()
   lint_msg <- rex::rex("Use paste(), not paste0(), to collapse a character vector when sep= is not used.")
 
-  expect_lint("paste(x, collapse = '')", NULL, linter)
-  expect_lint("paste0(a, b, collapse = '')", NULL, linter)
+  expect_no_lint("paste(x, collapse = '')", linter)
+  expect_no_lint("paste0(a, b, collapse = '')", linter)
   # pass-through can pass any number of arguments
-  expect_lint("paste0(..., collapse = '')", NULL, linter)
+  expect_no_lint("paste0(..., collapse = '')", linter)
   expect_lint("paste0(x, collapse = '')", lint_msg, linter)
   expect_lint("paste0(x, collapse = 'xxx')", lint_msg, linter)
   expect_lint("paste0(foo(x, y, z), collapse = '')", lint_msg, linter)
@@ -257,7 +254,7 @@ local({
   patrick::with_parameters_test_that(
     "paste0(collapse=...) is caught in pipes",
     {
-      expect_lint(sprintf('x %s paste0(y, collapse = "")', pipe), NULL, linter)
+      expect_no_lint(sprintf('x %s paste0(y, collapse = "")', pipe), linter)
       expect_lint(sprintf('x %s paste0(collapse = "")', pipe), lint_msg, linter)
     },
     pipe = pipes,
@@ -285,5 +282,5 @@ test_that("paste0(collapse=...) cases interacting with other rules are handled",
 
   # paste0(..., collapse=collapse) not directly mapped to file.path
   expect_lint("paste0(x, collapse = '/')", lint_msg, linter)
-  expect_lint("paste0(x, y, collapse = '/')", NULL, linter)
+  expect_no_lint("paste0(x, y, collapse = '/')", linter)
 })

--- a/tests/testthat/test-quotes_linter.R
+++ b/tests/testthat/test-quotes_linter.R
@@ -1,13 +1,13 @@
 test_that("quotes_linter skips allowed usages", {
   linter <- quotes_linter()
 
-  expect_lint("blah", NULL, linter)
-  expect_lint('"blah"', NULL, linter)
-  expect_lint('"\'blah"', NULL, linter)
-  expect_lint('"blah\'"', NULL, linter)
-  expect_lint('"\'blah\'"', NULL, linter)
-  expect_lint("'\"'", NULL, linter)
-  expect_lint("'\"blah\"'", NULL, linter)
+  expect_no_lint("blah", linter)
+  expect_no_lint('"blah"', linter)
+  expect_no_lint('"\'blah"', linter)
+  expect_no_lint('"blah\'"', linter)
+  expect_no_lint('"\'blah\'"', linter)
+  expect_no_lint("'\"'", linter)
+  expect_no_lint("'\"blah\"'", linter)
 })
 
 test_that("quotes_linter blocks disallowed usages", {
@@ -31,15 +31,15 @@ test_that("quotes_linter blocks disallowed usages", {
 test_that("quotes_linter skips allowed usages of delimiter='", {
   linter <- quotes_linter(delimiter = "'")
 
-  expect_lint("blah", NULL, linter)
-  expect_lint('"\'blah"', NULL, linter)
-  expect_lint('"blah\'"', NULL, linter)
-  expect_lint('"\'blah\'"', NULL, linter)
-  expect_lint("'\"'", NULL, linter)
-  expect_lint("'\"blah\"'", NULL, linter)
-  expect_lint("'blah'", NULL, linter)
-  expect_lint("fun('blah')", NULL, linter)
-  expect_lint("{'blah'}", NULL, linter)
+  expect_no_lint("blah", linter)
+  expect_no_lint('"\'blah"', linter)
+  expect_no_lint('"blah\'"', linter)
+  expect_no_lint('"\'blah\'"', linter)
+  expect_no_lint("'\"'", linter)
+  expect_no_lint("'\"blah\"'", linter)
+  expect_no_lint("'blah'", linter)
+  expect_no_lint("fun('blah')", linter)
+  expect_no_lint("{'blah'}", linter)
 })
 
 test_that("quotes_linter blocks disallowed usages of delimiter='", {
@@ -56,13 +56,12 @@ test_that("quotes_linter blocks disallowed usages of delimiter='", {
   )
 })
 
-test_that("handles R>=4.0.0 strings", {
-  skip_if_not_r_version("4.0.0")
+test_that("raw strings are handled correctly", {
   linter <- quotes_linter()
-  expect_lint('R"(hello \'\' there)"', NULL, linter)
+  expect_no_lint('R"(hello \'\' there)"', linter)
   expect_lint("R'( whoops )'", rex::rex("Only use double-quotes."), linter)
   expect_lint("R'---[ daisy ]---'", rex::rex("Only use double-quotes."), linter)
-  expect_lint("r'(\")'", NULL, linter)
+  expect_no_lint("r'(\")'", linter)
 })
 
 test_that("single_quotes_linter is deprecated", {
@@ -73,7 +72,7 @@ test_that("single_quotes_linter is deprecated", {
     "Use quotes_linter instead",
     fixed = TRUE
   )
-  expect_lint('"blah"', NULL, old_linter)
+  expect_no_lint('"blah"', old_linter)
   expect_lint("'blah'", "Only use double-quotes", old_linter)
 })
 

--- a/tests/testthat/test-string_boundary_linter.R
+++ b/tests/testthat/test-string_boundary_linter.R
@@ -2,53 +2,53 @@ test_that("string_boundary_linter skips allowed grepl() usages", {
   linter <- string_boundary_linter()
 
   # no known start/end anchor --> no lint
-  expect_lint("grepl(p1, x)", NULL, linter)
+  expect_no_lint("grepl(p1, x)", linter)
   # no start/end anchor --> no lint
-  expect_lint("grepl('abc', x)", NULL, linter)
+  expect_no_lint("grepl('abc', x)", linter)
   # regex pattern --> no lint
-  expect_lint("grepl('^[a-z]', x)", NULL, linter)
-  expect_lint("grepl('[a-z]$', x)", NULL, linter)
+  expect_no_lint("grepl('^[a-z]', x)", linter)
+  expect_no_lint("grepl('[a-z]$', x)", linter)
 
   # ignore.case --> no lint
-  expect_lint("grepl('^abc', x, ignore.case = TRUE)", NULL, linter)
-  expect_lint("grepl('^abc', x, ignore.case = ignore.case)", NULL, linter)
+  expect_no_lint("grepl('^abc', x, ignore.case = TRUE)", linter)
+  expect_no_lint("grepl('^abc', x, ignore.case = ignore.case)", linter)
 
   # fixed --> no lint
-  expect_lint("grepl('^abc', x, fixed = TRUE)", NULL, linter)
-  expect_lint("grepl('^abc', x, fixed = fixed)", NULL, linter)
+  expect_no_lint("grepl('^abc', x, fixed = TRUE)", linter)
+  expect_no_lint("grepl('^abc', x, fixed = fixed)", linter)
 })
 
 test_that("string_boundary_linter skips allowed str_detect() usages", {
   linter <- string_boundary_linter()
 
   # no known start/end anchor --> no lint
-  expect_lint("str_detect(x, p1)", NULL, linter)
+  expect_no_lint("str_detect(x, p1)", linter)
   # no start/end anchor --> no lint
-  expect_lint("str_detect(x, 'abc')", NULL, linter)
+  expect_no_lint("str_detect(x, 'abc')", linter)
   # regex pattern --> no lint
-  expect_lint("str_detect(x, '^[a-z]')", NULL, linter)
-  expect_lint("str_detect(x, '[a-z]$')", NULL, linter)
+  expect_no_lint("str_detect(x, '^[a-z]')", linter)
+  expect_no_lint("str_detect(x, '[a-z]$')", linter)
 })
 
 test_that("string_boundary_linter skips allowed substr()/substring() usages", {
   linter <- string_boundary_linter()
 
   # no comparison operator --> no lint
-  expect_lint("substr(x, start, end)", NULL, linter)
+  expect_no_lint("substr(x, start, end)", linter)
   # unknown indices --> no lint
-  expect_lint("substr(x, start, end) == 'a'", NULL, linter)
-  expect_lint("substring(x, start, end) == 'a'", NULL, linter)
+  expect_no_lint("substr(x, start, end) == 'a'", linter)
+  expect_no_lint("substring(x, start, end) == 'a'", linter)
   # using foo(nchar(.))
-  expect_lint("substring(x, nchar(x) - 4, nchar(x) - 1) == 'abc'", NULL, linter)
+  expect_no_lint("substring(x, nchar(x) - 4, nchar(x) - 1) == 'abc'", linter)
   # using nchar(), but not of the input
-  expect_lint("substring(x, nchar(y) - 4, nchar(y)) == 'abcd'", NULL, linter)
+  expect_no_lint("substring(x, nchar(y) - 4, nchar(y)) == 'abcd'", linter)
   # using x in nchar(), but on foo(input)
-  expect_lint("substring(x, nchar(foo(x)) - 4, nchar(foo(x))) == 'abcd'", NULL, linter)
+  expect_no_lint("substring(x, nchar(foo(x)) - 4, nchar(foo(x))) == 'abcd'", linter)
 
   # _close_ to equivalent, but not so in general -- e.g.
   #   substring(s <- "abcdefg", 2L) == "efg" is not TRUE, but endsWith(s, "efg")
   #   is. And if `s` contains strings of varying lengths, there's no equivalent.
-  expect_lint("substring(x, 2L)", NULL, linter)
+  expect_no_lint("substring(x, 2L)", linter)
 })
 
 test_that("string_boundary_linter blocks simple disallowed grepl() usages", {
@@ -103,8 +103,8 @@ test_that("string_boundary_linter blocks disallowed substr()/substring() usage",
 test_that("plain ^ or $ are skipped", {
   linter <- string_boundary_linter()
 
-  expect_lint('grepl("^", x)', NULL, linter)
-  expect_lint('grepl("$", x)', NULL, linter)
+  expect_no_lint('grepl("^", x)', linter)
+  expect_no_lint('grepl("$", x)', linter)
 })
 
 test_that("substr inverted tests are caught as well", {
@@ -122,11 +122,10 @@ test_that("substr inverted tests are caught as well", {
   )
 })
 
-test_that("R>=4 raw strings are detected", {
+test_that("raw strings are detected", {
   linter <- string_boundary_linter()
 
-  skip_if_not_r_version("4.0.0")
-  expect_lint('grepl(R"(^.{3})", x)', NULL, linter)
+  expect_no_lint('grepl(R"(^.{3})", x)', linter)
   expect_lint(
     'grepl(R"(^abc)", x)',
     rex::rex("Use !is.na(x) & startsWith(x, string) to detect a fixed initial substring,"),
@@ -137,8 +136,8 @@ test_that("R>=4 raw strings are detected", {
 test_that("grepl() can optionally be ignored", {
   linter <- string_boundary_linter(allow_grepl = TRUE)
 
-  expect_lint("grepl('^abc', x)", NULL, linter)
-  expect_lint("grepl('xyz$', x)", NULL, linter)
+  expect_no_lint("grepl('^abc', x)", linter)
+  expect_no_lint("grepl('xyz$', x)", linter)
 })
 
 test_that("whole-string regex recommends ==, not {starts,ends}With()", {


### PR DESCRIPTION
Also continue with `expect_lint(, NULL,)` -> `expect_no_lint(,)` transition in the touched files