### PR TITLE
Use libxml2-dev to install xml2 in devcontainer

### DIFF
--- a/.devcontainer/r-devel/Dockerfile
+++ b/.devcontainer/r-devel/Dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/rhub/r-minimal:devel
 
 RUN apk update && \
-  apk add --no-cache git gcc g++ libxml2 linux-headers musl-dev
+  apk add --no-cache git gcc g++ libxml2-dev linux-headers musl-dev
 
 COPY DESCRIPTION .
 


### PR DESCRIPTION
Devcontainer-only, so skipping review.