### PR TITLE
Clarify why `while (TRUE)` is discouraged

### DIFF
--- a/R/repeat_linter.R
+++ b/R/repeat_linter.R
@@ -1,6 +1,7 @@
 #' Repeat linter
 #'
-#' Check that `while (TRUE)` is not used for infinite loops.
+#' Check that `while (TRUE)` is not used for infinite loops. While this is valid
+#' R code, using `repeat {}` is more explicit.
 #'
 #' @examples
 #' # will produce lints

--- a/man/repeat_linter.Rd
+++ b/man/repeat_linter.Rd
@@ -7,7 +7,8 @@
 repeat_linter()
 }
 \description{
-Check that \verb{while (TRUE)} is not used for infinite loops.
+Check that \verb{while (TRUE)} is not used for infinite loops. While this is valid
+R code, using \code{repeat {}} is more explicit.
 }
 \examples{
 # will produce lints


### PR DESCRIPTION
It wasn't clear to me that the only reason to prefer `while (TRUE)` was readability, so I think this clarifies a bit ("readability" is listed in the tags section but other lints usually have the explanation in the description section).

