### PR TITLE
Clarify example of `absolute_path_linter`

### DIFF
--- a/R/absolute_path_linter.R
+++ b/R/absolute_path_linter.R
@@ -11,7 +11,7 @@
 #' @examples
 #' # will produce lints
 #' lint(
-#'   text = 'R"--[/blah/file.txt]--"',
+#'   text = 'R"(/blah/file.txt)"',
 #'   linters = absolute_path_linter()
 #' )
 #'

--- a/man/absolute_path_linter.Rd
+++ b/man/absolute_path_linter.Rd
@@ -20,7 +20,7 @@ Check that no absolute paths are used (e.g. "/var", "C:\\System", "~/docs").
 \examples{
 # will produce lints
 lint(
-  text = 'R"--[/blah/file.txt]--"',
+  text = 'R"(/blah/file.txt)"',
   linters = absolute_path_linter()
 )
 


### PR DESCRIPTION
The example of `absolute_path_linter` was a bit confusing to me because the raw string syntax used differs between the failing and the passing cases.