### PR TITLE
Remove duplicated condition from paren_body_linter()

### DIFF
--- a/R/paren_body_linter.R
+++ b/R/paren_body_linter.R
@@ -36,7 +36,6 @@ paren_body_linter <- make_linter_from_xpath(
       or preceding-sibling::OP-LAMBDA
       or preceding-sibling::IF
       or preceding-sibling::WHILE
-      or preceding-sibling::OP-LAMBDA
     )
   ]
     /following-sibling::expr[1]


### PR DESCRIPTION
The check on `OP-LAMBDA` occurred twice.