### PR TITLE
Adjust fix for testthat 3.3.0+

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 * `assignment_linter()` no longer errors if `"%<>%"` is an allowed operator (#2850, @AshesITR).
 * `condition_call_linter()` no longer covers cases where the object type in the ellipsis cannot be determined with certainty (#2888, #2890, @Bisaloo). In particular, this fixes the known false positive of custom conditions created via `errorCondition()` or `warningCondition()` not being compatible with the `call.` argument in `stop()` or `warning()`.
 * `package_hooks_linter()` now validates `.onUnload()` hook signatures, requiring exactly one argument starting with 'lib' (#2940, @emmanuel-ferdman).
+* `expect_lint()` conforms to {testthat} v3.3.0+ rules for custom expectations, namely that they produce either exactly one success or exactly one failure (#2937, @hadley).
 
 ## Changes to default linters
 

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -87,8 +87,6 @@ expect_lint <- function(content, checks, ..., file = NULL, language = "en", igno
   }
 
   expect_lint_impl_(lints, checks)
-
-  testthat::succeed()
 }
 
 #' NB: must _not_ succeed(), should only fail() or abort()
@@ -122,11 +120,13 @@ expect_lint_impl_ <- function(lints, checks) {
         return(testthat::fail(sprintf(
           "check #%d: %s %s did not match %s",
           # deparse ensures that NULL, list(), etc are handled gracefully
-          itr, field, deparse(value), deparse(check)
+          itr, field, deparse(value), deparse(check_field)
         )))
       }
     }
   }
+
+  testthat::succeed()
 }
 
 #' @rdname expect_lint

--- a/tests/testthat/test-expect_lint.R
+++ b/tests/testthat/test-expect_lint.R
@@ -20,7 +20,7 @@ test_that("single check", {
   expect_failure(expect_lint("a=1", "asdf", linter))
   expect_success(expect_lint("a=1", c(message = lint_msg), linter))
   expect_failure(expect_lint("a=1", c(message = NULL), linter))
-  expect_success(expect_lint("a=1", c(message = lint_msg, line_number = 1L), linter))
+  expect_success(expect_lint("a=1", list(message = lint_msg, line_number = 1L), linter))
   expect_failure(expect_lint("a=1", c(line_number = 2L, message = lint_msg), linter))
 
   expect_error(expect_lint("a=1", c(message = lint_msg, lineXXX = 1L), linter), "Check 1 has an invalid field: lineXXX")
@@ -41,11 +41,11 @@ test_that("multiple checks", {
   expect_success(expect_lint("a=1; b=2", list(lint_msg, lint_msg), linter))
   expect_success(expect_lint("a=1; b=2", list(c(message = lint_msg), c(message = lint_msg)), linter))
   expect_success(expect_lint("a=1; b=2", list(c(line_number = 1L), c(linter = "assignment_linter")), linter))
-  expect_success(expect_lint("a=1; b=2", list(lint_msg, c(line = "a=1; b=2", type = "warning")), linter))
+  expect_success(expect_lint("a=1; b=2", list(lint_msg, list(line = "a=1; b=2", type = "style")), linter))
   expect_success(expect_lint("a=1\nb=2", list(c(line_number = 1L), c(line_number = 2L)), linter))
   expect_failure(expect_lint("a=1\nb=2", list(c(line_number = 2L), c(line_number = 2L)), linter))
 
-  expect_success(expect_lint("a=1; b=2", list(list(line_number = 1L), list(line_number = 2L)), linter))
+  expect_success(expect_lint("a=1\nb=2", list(list(line_number = 1L), list(line_number = 2L)), linter))
   expect_failure(expect_lint("a=1; b=2", list(list(line_number = 2L), list(line_number = 2L)), linter))
   expect_success(
     expect_lint("\t1\n\t2", list("tabs", list(column_number = 1L, ranges = list(c(1L, 1L)))), whitespace_linter())


### PR DESCRIPTION
Follow-up to #2937.

`fail()` does not interrupt execution, so we need to put the `succeed()` in a place where it can't be reached.

The other changes were existing mistakes in the suite that are exposed by having `expect_lint()` WAI.