### PR TITLE
Revert "Re-generate docs from roxygen2"

### DIFF
--- a/man/any_is_na_linter.Rd
+++ b/man/any_is_na_linter.Rd
@@ -7,7 +7,7 @@
 any_is_na_linter()
 }
 \description{
-\code{\link[base:anyNA]{base::anyNA()}} exists as a replacement for \code{any(is.na(x))} which is more efficient
+\code{\link[base:NA]{base::anyNA()}} exists as a replacement for \code{any(is.na(x))} which is more efficient
 for simple objects, and is at worst equally efficient.
 Therefore, it should be used in all situations instead of the latter.
 }

--- a/man/condition_message_linter.Rd
+++ b/man/condition_message_linter.Rd
@@ -8,7 +8,7 @@ condition_message_linter()
 }
 \description{
 This linter discourages combining condition functions like \code{\link[=stop]{stop()}} with string concatenation
-functions \code{\link[base:paste]{base::paste()}} and \code{\link[base:paste0]{base::paste0()}}. This is because
+functions \code{\link[base:paste]{base::paste()}} and \code{\link[base:paste]{base::paste0()}}. This is because
 \itemize{
 \item \code{stop(paste0(...))} is redundant as it is exactly equivalent to \code{stop(...)}
 \item \code{stop(paste(...))} is similarly equivalent to \code{stop(...)} with separators (see examples)

--- a/man/paste_linter.Rd
+++ b/man/paste_linter.Rd
@@ -29,7 +29,7 @@ when it comes at the beginning or end of the input, to avoid requiring empty inp
 The following issues are linted by default by this linter
 (see arguments for which can be de-activated optionally):
 \enumerate{
-\item Block usage of \code{\link[base:paste]{base::paste()}} with \code{sep = ""}. \code{\link[base:paste0]{base::paste0()}} is a faster, more concise alternative.
+\item Block usage of \code{\link[base:paste]{base::paste()}} with \code{sep = ""}. \code{\link[base:paste]{base::paste0()}} is a faster, more concise alternative.
 \item Block usage of \code{paste()} or \code{paste0()} with \code{collapse = ", "}. \code{\link[=toString]{toString()}} is a direct
 wrapper for this, and alternatives like \code{\link[glue:glue_collapse]{glue::glue_collapse()}} might give better messages for humans.
 \item Block usage of \code{paste0()} that supplies \verb{sep=} -- this is not a formal argument to \code{paste0}, and

--- a/man/read_settings.Rd
+++ b/man/read_settings.Rd
@@ -24,7 +24,7 @@ Lintr searches for settings for a given source file in the following order:
 \details{
 The default linter_file name is \code{.lintr} but it can be changed with option \code{lintr.linter_file}
 or the environment variable \code{R_LINTR_LINTER_FILE}
-This file is a DCF file, see \code{\link[base:read.dcf]{base::read.dcf()}} for details.
+This file is a DCF file, see \code{\link[base:dcf]{base::read.dcf()}} for details.
 Here is an example of a \code{.lintr} file:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{linters: linters_with_defaults(

--- a/man/seq_linter.Rd
+++ b/man/seq_linter.Rd
@@ -15,8 +15,8 @@ conjunction with \code{seq()} (e.g., \code{seq(length(...))}, \code{seq(nrow(...
 Additionally, it checks for \code{1:n()} (from \code{{dplyr}}) and \code{1:.N} (from \code{{data.table}}).
 
 These often cause bugs when the right-hand side is zero.
-Instead, it is safer to use \code{\link[base:seq_len]{base::seq_len()}} (to create a sequence of a specified \emph{length}) or
-\code{\link[base:seq_along]{base::seq_along()}} (to create a sequence \emph{along} an object).
+Instead, it is safer to use \code{\link[base:seq]{base::seq_len()}} (to create a sequence of a specified \emph{length}) or
+\code{\link[base:seq]{base::seq_along()}} (to create a sequence \emph{along} an object).
 }
 \examples{
 # will produce lints

--- a/man/string_boundary_linter.Rd
+++ b/man/string_boundary_linter.Rd
@@ -19,7 +19,7 @@ c.f. \code{startsWith(x, "abc")}, \code{grepl("^abc", x)},
 \code{substr(x, 1L, 3L) == "abc"}.
 }
 \details{
-Ditto for using \code{\link[base:endsWith]{base::endsWith()}} to detect fixed terminal substrings.
+Ditto for using \code{\link[base:startsWith]{base::endsWith()}} to detect fixed terminal substrings.
 
 Note that there is a difference in behavior between how \code{grepl()} and \code{startsWith()}
 (and \code{endsWith()}) handle missing values. In particular, for \code{grepl()}, \code{NA} inputs


### PR DESCRIPTION
Reverts r-lib/lintr#2973

I see, actually this was happening because the minimal codespaces image deletes the base documentation which interferes with how {roxygen2} resolves links