### PR TITLE
Drop skip_if_not_r_version for skip_unless_r

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
     rlang,
     rmarkdown,
     rstudioapi (>= 0.2),
-    testthat (>= 3.2.1),
+    testthat (>= 3.3.0),
     tibble,
     tufte,
     withr (>= 2.5.0)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -57,12 +57,6 @@ with_config <- function(contents, code, config_dir = ".", filename = ".lintr") {
   code
 }
 
-skip_if_not_r_version <- function(min_version) {
-  if (getRversion() < min_version) {
-    testthat::skip(paste("R version at least", min_version, "is required"))
-  }
-}
-
 skip_if_not_utf8_locale <- function() {
   testthat::skip_if_not(l10n_info()[["UTF-8"]], "Not a UTF-8 locale")
 }

--- a/tests/testthat/test-one_call_pipe_linter.R
+++ b/tests/testthat/test-one_call_pipe_linter.R
@@ -96,7 +96,7 @@ test_that("Native pipes are handled as well", {
 })
 
 test_that("one_call_pipe_linter skips data.table chains with native pipe", {
-  skip_if_not_r_version("4.3.0")
+  skip_unless_r(">= 4.3.0")
 
   linter <- one_call_pipe_linter()
   lint_msg <- rex::rex("Avoid pipe |> for expressions with only a single call.")


### PR DESCRIPTION
This is from the very recent (November '25) {testthat} release.

We might just leave this PR pending for a while to let that version bake, OTOH, {lintr} was also just released with no immediate plans for its own CRAN push.