### PR TITLE
Implement `call_is_undesirable` parameter in undesirable_operator_linter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 * Excluding `cyclocomp_linter()` in `available_linters()` or `linters_with_tags()`, which requires the weak dependency {cyclocomp}, no longer emits a warning (#2909, @MichaelChirico).
 * `repeat_linter()` no longer errors when `while` is in a column to the right of `}` (#2828, @MichaelChirico).
+* `undesirable_operator_linter(call_is_undesirable = FALSE)` now correctly skips prefix notation like `` `:::`(pkg, fun) `` (#2999, @emmanuel-ferdman).
 
 ## New and improved features
 

--- a/R/undesirable_operator_linter.R
+++ b/R/undesirable_operator_linter.R
@@ -117,18 +117,24 @@ undesirable_operator_linter <- function(op = default_undesirable_operators,
 
   Linter(linter_level = "expression", function(source_expression) {
     xml <- source_expression$xml_parsed_content
-    op_calls <- source_expression$xml_find_function_calls(quoted_op)
 
     infix_expr <- xml_find_all(xml, infix_xpath)
 
-    operator <- c(xml_text(infix_expr), gsub("^`|`$", "", xml_text(op_calls)))
+    all_expr <- infix_expr
+    operator <- xml_text(infix_expr)
+    if (call_is_undesirable) {
+      op_calls <- source_expression$xml_find_function_calls(quoted_op)
+      all_expr <- combine_nodesets(all_expr, op_calls)
+      operator <- c(operator, gsub("^`|`$", "", xml_text(op_calls)))
+    }
+
     lint_message <- sprintf("Avoid undesirable operator `%s`.", operator)
     alternative <- op[operator]
     has_alternative <- !is.na(alternative)
     lint_message[has_alternative] <- paste(lint_message[has_alternative], alternative[has_alternative])
 
     xml_nodes_to_lints(
-      combine_nodesets(infix_expr, op_calls),
+      all_expr,
       source_expression,
       lint_message,
       type = "warning"

--- a/tests/testthat/test-undesirable_operator_linter.R
+++ b/tests/testthat/test-undesirable_operator_linter.R
@@ -104,3 +104,13 @@ test_that("Default recommendations can be specified multiple ways", {
   expect_lint(lint_str, lint_message, linter_mixed1)
   expect_lint(lint_str, lint_message, linter_mixed2)
 })
+
+test_that("call_is_undesirable = FALSE doesn't lint prefix notation", {
+  linter <- undesirable_operator_linter(call_is_undesirable = FALSE)
+  lint_message <- rex::rex("Avoid undesirable operator `:::`.")
+
+  expect_no_lint("`:::`(utils, hasName)", linter)
+  expect_no_lint("`<<-`(x, 1)", linter)
+
+  expect_lint("utils:::hasName", lint_message, linter)
+})


### PR DESCRIPTION
## PR Summary
The `call_is_undesirable` parameter was added in #2761 but never actually wired up - the linter always checked prefix calls regardless of the setting. Now when you pass `call_is_undesirable = FALSE`, prefix notation like `:::(pkg, fun)` is properly skipped while still catching infix usage like `pkg:::fun`.

Fixes #2999