### PR TITLE
Add personal website link for Indrajeet Patil

### DIFF
--- a/pkgdown/_pkgdown.yaml
+++ b/pkgdown/_pkgdown.yaml
@@ -1,5 +1,9 @@
 url: https://lintr.r-lib.org
 
+authors:
+  Indrajeet Patil:
+    href: https://indrajeetpatil.github.io/
+
 template:
   bootstrap: 5
   light-switch: true


### PR DESCRIPTION
Adds an `authors` entry in `_pkgdown.yaml` so that Indrajeet Patil's name on the pkgdown site links to his personal website.