### PR TITLE
Custom linter for expect_no_lint

### DIFF
--- a/.lintr.R
+++ b/.lintr.R
@@ -1,3 +1,9 @@
+expect_no_lint_linter <- make_linter_from_xpath(
+  "//SYMBOL_FUNCTION_CALL[text() = 'expect_lint']
+    /parent::expr
+    /parent::expr[expr[3][NULL_CONST]]",
+  "Use expect_no_lint() to test for the lack of lints"
+)
 linters <- all_linters(
   backport_linter("3.6.0", except = c("R_user_dir", "deparse1", "...names")),
   line_length_linter(120L),
@@ -43,6 +49,7 @@ linters <- all_linters(
     symbol_is_undesirable = FALSE
   ),
   unnecessary_concatenation_linter(allow_single_expression = FALSE),
+  expect_no_lint_linter(),
   absolute_path_linter = NULL,
   library_call_linter = NULL,
   nonportable_path_linter = NULL,
@@ -52,6 +59,8 @@ linters <- all_linters(
   # exclude; we use customized version above
   undesirable_function_linter = NULL
 )
+rm(expect_no_lint_linter)
+
 exclusions <- list(
   `inst/doc/creating_linters.R` = 1L,
   "inst/example/bad.R",

--- a/R/expect_lint.R
+++ b/R/expect_lint.R
@@ -138,6 +138,7 @@ expect_lint_impl_ <- function(lints, checks, trace_env = rlang::caller_env()) {
 #' @export
 expect_no_lint <- function(content, ..., file = NULL, language = "en") {
   require_testthat()
+  # nolint next: expect_no_lint_linter.
   expect_lint(content, NULL, ..., file = file, language = language)
 }
 

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -222,60 +222,28 @@ test_that("next-line exclusion works", { # nofuzz
 })
 
 test_that("capture groups work as intended (#2831)", { # nofuzz: assignment comment_injection
+  linter <- assignment_linter()
+
   expect_lint(
     "x = 1",
     list(rex::rex("Use <- for assignment, not =.")),
-    linters = assignment_linter(),
+    linters = linter,
     exclude = "(a)|(b)"
   )
-  expect_lint(
-    "a = 1",
-    NULL,
-    linters = assignment_linter(),
-    exclude = "(a)|(b)"
-  )
-
-  expect_lint(
-    "a = 1",
-    NULL,
-    linters = assignment_linter(),
-    exclude = "(?:a)|(?:b)"
-  )
-
-  expect_lint(
-    "a = 1",
-    NULL,
-    linters = assignment_linter(),
-    exclude = "(?:a)|(b)"
-  )
-  expect_lint(
-    "b = 1",
-    NULL,
-    linters = assignment_linter(),
-    exclude = "(a)|(?:b)"
-  )
+  expect_no_lint("a = 1", linters = linter, exclude = "(a)|(b)")
+  expect_no_lint("a = 1", linters = linter, exclude = "(?:a)|(?:b)")
+  expect_no_lint("a = 1", linters = linter, exclude = "(?:a)|(b)")
+  expect_no_lint("b = 1", linters = linter, exclude = "(a)|(?:b)")
 
   # named groups
-  expect_lint(
-    "a = 1",
-    NULL,
-    linters = assignment_linter(),
-    exclude = "(?<group1>a)|(?<group2>b)"
-  )
-
+  expect_no_lint("a = 1", linters = linter, exclude = "(?<group1>a)|(?<group2>b)")
   # nested groups
-  expect_lint(
-    "a = 1",
-    NULL,
-    linters = assignment_linter(),
-    exclude = "((a)|(b))"
-  )
+  expect_no_lint("a = 1", linters = linter, exclude = "((a)|(b))")
 
   # exclude_start / exclude_end with capture groups
-  expect_lint(
+  expect_no_lint(
     "x = 1 # nolint start\ny = 2\nz = 3 # nolint end",
-    NULL,
-    linters = assignment_linter(),
+    linters = linter,
     exclude_start = "(# nolint start)",
     exclude_end = "(# nolint end)"
   )

--- a/tests/testthat/test-exclusions.R
+++ b/tests/testthat/test-exclusions.R
@@ -223,13 +223,9 @@ test_that("next-line exclusion works", { # nofuzz
 
 test_that("capture groups work as intended (#2831)", { # nofuzz: assignment comment_injection
   linter <- assignment_linter()
+  lint_msg <- rex::rex("Use <- for assignment, not =.")
 
-  expect_lint(
-    "x = 1",
-    list(rex::rex("Use <- for assignment, not =.")),
-    linters = linter,
-    exclude = "(a)|(b)"
-  )
+  expect_lint("x = 1", lint_msg, linters = linter, exclude = "(a)|(b)")
   expect_no_lint("a = 1", linters = linter, exclude = "(a)|(b)")
   expect_no_lint("a = 1", linters = linter, exclude = "(?:a)|(?:b)")
   expect_no_lint("a = 1", linters = linter, exclude = "(?:a)|(b)")
@@ -242,7 +238,11 @@ test_that("capture groups work as intended (#2831)", { # nofuzz: assignment comm
 
   # exclude_start / exclude_end with capture groups
   expect_no_lint(
-    "x = 1 # nolint start\ny = 2\nz = 3 # nolint end",
+    trim_some("
+      x = 1 # nolint start
+      y = 2
+      z = 3 # nolint end
+    "),
     linters = linter,
     exclude_start = "(# nolint start)",
     exclude_end = "(# nolint end)"
@@ -250,8 +250,11 @@ test_that("capture groups work as intended (#2831)", { # nofuzz: assignment comm
 
   # exclude_next with capture groups
   expect_lint(
-    "x = 1 # nolint next\ny = 2",
-    list(message = "Use <- for assignment, not =.", line_number = 1L),
+    trim_some("
+      x = 1 # nolint next
+      y = 2
+    "),
+    list(lint_msg, line_number = 1L),
     linters = assignment_linter(),
     exclude_next = "(# nolint next)"
   )


### PR DESCRIPTION
Putting it directly in .lintr.R for now.  My sense is this is not something we want to ship+export either.

In {data.table}, we've taken a slightly different approach of putting them in a folder and sourcing them:

https://github.com/Rdatatable/data.table/blob/0b57d38982fb30f70125ebd5eb2be1cc06d988d9/.ci/.lintr.R#L1-L6

Open to starting that way here too.