### PR TITLE
Amend test to work before+after r-devel change about read.dcf warning aroud trailing newlines

### DIFF
--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -1,16 +1,19 @@
 test_that("read_config_file() warns if the config file does not end in a newline", {
   .lintr <- withr::local_tempfile()
-  # temporarily disable warning->error conversion, see below
-  withr::local_options(lintr.linter_file = .lintr, warn = 0L)
+  withr::local_options(lintr.linter_file = .lintr)
   withr::local_dir(withr::local_tempdir())
 
   # cat() not writeLines() to ensure no trailing \n
   cat("linters: linters_with_defaults(brace_linter = NULL)", file = .lintr)
   writeLines("a <- 1", "aaa.R")
+
   # on R 4.7.0+, read.dcf() uses warn=FALSE in internal readLines(), so we
   #   no longer catch a warning here as part of the fix for old #160.
-  #   expect_no_error() ensures this test passes all supported versions.
-  expect_no_error(lint_dir())
+  if (inherits(tryCatch(read.dcf(.lintr), condition = identity), "warning")) {
+    expect_warning(lint_dir(), "Warning encountered while loading config", fixed = TRUE)
+  } else {
+    expect_silent(lint_dir())
+  }
 })
 
 test_that("it gives informative errors if the config file contains errors", {

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -1,3 +1,14 @@
+test_that("read_config_file() warns if the config file does not end in a newline", {
+  .lintr <- withr::local_tempfile()
+  withr::local_options(lintr.linter_file = .lintr)
+  withr::local_dir(withr::local_tempdir())
+
+  # cat() not writeLines() to ensure no trailing \n
+  cat("linters: linters_with_defaults(brace_linter = NULL)", file = .lintr)
+  writeLines("a <- 1", "aaa.R")
+  expect_warning(lint_dir(), "Warning encountered while loading config", fixed = TRUE)
+})
+
 test_that("it gives informative errors if the config file contains errors", {
   .lintr <- withr::local_tempfile(lines = c(
     "linters: linters_with_defaults(",

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -1,7 +1,7 @@
 test_that("read_config_file() warns if the config file does not end in a newline", {
   .lintr <- withr::local_tempfile()
   # temporarily disable warning->error conversion, see below
-  withr::local_options(lintr.linter_file = .lintr, warn = 0)
+  withr::local_options(lintr.linter_file = .lintr, warn = 0L)
   withr::local_dir(withr::local_tempdir())
 
   # cat() not writeLines() to ensure no trailing \n

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -6,7 +6,10 @@ test_that("read_config_file() warns if the config file does not end in a newline
   # cat() not writeLines() to ensure no trailing \n
   cat("linters: linters_with_defaults(brace_linter = NULL)", file = .lintr)
   writeLines("a <- 1", "aaa.R")
-  expect_warning(lint_dir(), "Warning encountered while loading config", fixed = TRUE)
+  # on R 4.7.0+, read.dcf() uses warn=FALSE in internal readLines(), so we
+  #   no longer catch a warning here as part of the fix for old #160.
+  #   expect_no_error() ensures this test passes all supported versions.
+  expect_no_error(lint_dir())
 })
 
 test_that("it gives informative errors if the config file contains errors", {

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -1,14 +1,3 @@
-test_that("read_config_file() warns if the config file does not end in a newline", {
-  .lintr <- withr::local_tempfile()
-  withr::local_options(lintr.linter_file = .lintr)
-  withr::local_dir(withr::local_tempdir())
-
-  # cat() not writeLines() to ensure no trailing \n
-  cat("linters: linters_with_defaults(brace_linter = NULL)", file = .lintr)
-  writeLines("a <- 1", "aaa.R")
-  expect_warning(lint_dir(), "Warning encountered while loading config", fixed = TRUE)
-})
-
 test_that("it gives informative errors if the config file contains errors", {
   .lintr <- withr::local_tempfile(lines = c(
     "linters: linters_with_defaults(",

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -1,6 +1,7 @@
 test_that("read_config_file() warns if the config file does not end in a newline", {
   .lintr <- withr::local_tempfile()
-  withr::local_options(lintr.linter_file = .lintr)
+  # temporarily disable warning->error conversion, see below
+  withr::local_options(lintr.linter_file = .lintr, warn = 0)
   withr::local_dir(withr::local_tempdir())
 
   # cat() not writeLines() to ensure no trailing \n

--- a/tests/testthat/test-settings.R
+++ b/tests/testthat/test-settings.R
@@ -9,7 +9,7 @@ test_that("read_config_file() warns if the config file does not end in a newline
 
   # on R 4.7.0+, read.dcf() uses warn=FALSE in internal readLines(), so we
   #   no longer catch a warning here as part of the fix for old #160.
-  if (inherits(tryCatch(read.dcf(.lintr), condition = identity), "warning")) {
+  if (inherits(tryCatch(read.dcf(.lintr, all = TRUE), condition = identity), "warning")) {
     expect_warning(lint_dir(), "Warning encountered while loading config", fixed = TRUE)
   } else {
     expect_silent(lint_dir())


### PR DESCRIPTION
This became a warning in #2254 and was previously (b4484df854b2e93e66ffc05024f285828c760593) an error.

In turn this came from R itself using `readLines(warn=TRUE)` in `read.dcf()`, which it no longer does ([r90200](https://github.com/r-devel/r-svn/commit/af4426e4c351b935ecce1bdc6597a03a236db89e)).

Leave the test intact as it ensures a newline-less DCF-style config doesn't cause an error, at least (#160).

I don't think a NEWS entry is warranted.