### PR TITLE
Add an expectation for the use_lintr() message to avoid test log noise

### DIFF
--- a/tests/testthat/test-use_lintr.R
+++ b/tests/testthat/test-use_lintr.R
@@ -61,12 +61,15 @@ test_that("No .Rbuildignore is filled if pattern already present", {
   )
   ignore_path <- file.path(tmp, ".Rbuildignore")
   ignore <- c("^fu$", "^\\.lintr$", "^bar$")
-  writeLines(
-    ignore,
-    ignore_path
-  )
+  writeLines(ignore, ignore_path)
 
-  lintr_file <- use_lintr(path = tmp, type = "full")
+  expect_message(
+    {
+      lintr_file <- use_lintr(path = tmp, type = "full")
+    },
+    "^\\.lintr$ is already ignored in `.Rbuildignore`.",
+    fixed = TRUE
+  )
   expect_identical(readLines(ignore_path), ignore)
 })
 


### PR DESCRIPTION
This can be seen in any recent testthat log e.g. https://github.com/r-lib/lintr/actions/runs/28804847394/job/85417586453 (Show testthat output)