### PR TITLE
namespace_linter() extended for finding redundant '::'/':::' usage for already-imported symbols

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,8 @@
    + recommends usage of `!is.unsorted(x)` over `identical(x, sort(x))` (#2921, @Bisaloo).
    + recommends usage of `sort(x, decreasing = TRUE)` over `rev(sort(x))` (#3066, @Bisaloo).
 * `paste_linter()` lints `expression(paste(., sep = ""))` because the `paste` inside an expression doesn't support the `sep` argument (#2945, @mcol).
+* `namespace_linter()` detects functions accessed with `::` or `:::` when they are already imported into the package's `NAMESPACE` (`check_imports = TRUE`; #2081, @MichaelChirico).
+
 
 ### Lint accuracy fixes: removing false positives
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -54,7 +54,7 @@
    + recommends usage of `!is.unsorted(x)` over `identical(x, sort(x))` (#2921, @Bisaloo).
    + recommends usage of `sort(x, decreasing = TRUE)` over `rev(sort(x))` (#3066, @Bisaloo).
 * `paste_linter()` lints `expression(paste(., sep = ""))` because the `paste` inside an expression doesn't support the `sep` argument (#2945, @mcol).
-* `namespace_linter()` detects functions accessed with `::` or `:::` when they are already imported into the package's `NAMESPACE` (`check_imports = TRUE`; #2081, @MichaelChirico).
+* `namespace_linter()` detects functions accessed with `::` or `:::` when they are already imported into the package's `NAMESPACE` (#2081, @MichaelChirico).
 
 
 ### Lint accuracy fixes: removing false positives

--- a/R/condition_call_linter.R
+++ b/R/condition_call_linter.R
@@ -58,18 +58,18 @@
 condition_call_linter <- function(display_call = FALSE) {
 
   str_fct <- c("sprintf", "gettextf", "paste", "paste0", "format", "tr_")
-  str_literal_or_fct <- glue::glue("
+  str_literal_or_fct <- glue("
     STR_CONST
     or expr/SYMBOL_FUNCTION_CALL[ { xp_text_in_table(str_fct) }]
   ")
 
-  call_xpath <- glue::glue("
+  call_xpath <- glue("
     following-sibling::expr[ {str_literal_or_fct} ]
     and following-sibling::SYMBOL_SUB[text() = 'call.']
       /following-sibling::expr[1]
       /NUM_CONST[text() = '{!display_call}']
   ")
-  no_call_xpath <- glue::glue("
+  no_call_xpath <- glue("
     following-sibling::expr[ {str_literal_or_fct} ]
     and parent::expr[not(SYMBOL_SUB[text() = 'call.'])]
   ")
@@ -88,7 +88,7 @@ condition_call_linter <- function(display_call = FALSE) {
     msg_fmt <- "Use %s(., call. = FALSE) not to display the call in an error message."
   }
 
-  xpath <- glue::glue("./self::*[{call_cond}]/parent::expr")
+  xpath <- glue("./self::*[{call_cond}]/parent::expr")
 
   Linter(linter_level = "expression", function(source_expression) {
     xml_calls <- source_expression$xml_find_function_calls(c("stop", "warning"))

--- a/R/cyclocomp_linter.R
+++ b/R/cyclocomp_linter.R
@@ -24,7 +24,7 @@
 cyclocomp_linter <- function(complexity_limit = 15L) {
   # nocov start
   if (!requireNamespace("cyclocomp", quietly = TRUE)) {
-    cli::cli_warn(c(
+    cli_warn(c(
       "Cyclocomp complexity is computed using {.fn cyclocomp::cyclocomp}.",
       i = "Please install the needed {.pkg cyclocomp} package."
     ))

--- a/R/expect_identical_linter.R
+++ b/R/expect_identical_linter.R
@@ -60,7 +60,7 @@ expect_identical_linter <- function() {
   #   - skip cases like expect_equal(x, 1.02) or the constant vector version
   #     where a numeric constant indicates inexact testing is preferable
   #   - skip calls using dots (`...`); see tests
-  non_integer <- glue::glue("
+  non_integer <- glue("
     NUM_CONST[contains(text(), '.')]
     or (
       OP-MINUS
@@ -69,7 +69,7 @@ expect_identical_linter <- function() {
     )
   ")
 
-  expect_equal_xpath <- glue::glue("
+  expect_equal_xpath <- glue("
   self::*[not(
       following-sibling::EQ_SUB
       or following-sibling::expr[

--- a/R/length_test_linter.R
+++ b/R/length_test_linter.R
@@ -43,7 +43,7 @@
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
 length_test_linter <- function() {
-  xpath <- glue::glue("
+  xpath <- glue("
   following-sibling::expr[{ xp_or(infix_metadata$xml_tag[infix_metadata$comparator]) }]
     /parent::expr
   ")

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -6,6 +6,8 @@
 #'
 #' @param check_exports Check if `symbol` is exported from `namespace` in `namespace::symbol` calls.
 #' @param check_nonexports Check if `symbol` exists in `namespace` in `namespace:::symbol` calls.
+#' @param check_imports Check if `symbol` is already imported from `namespace` in `namespace::symbol` or
+#'   `namespace:::symbol` calls.
 #'
 #' @examples
 #' # will produce lints
@@ -35,10 +37,15 @@
 #'   linters = namespace_linter(check_nonexports = FALSE)
 #' )
 #'
+#' lint(
+#'   text = "stats::sd(c(1, 2, 3))",
+#'   linters = namespace_linter(check_imports = FALSE)
+#' )
+#'
 #' @evalRd rd_tags("namespace_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
-namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
+namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE, check_imports = TRUE) {
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
 
@@ -72,44 +79,67 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
       package_nodes <- package_nodes[installed]
     }
 
-    if (!check_exports && !check_nonexports) {
+    if (!check_exports && !check_nonexports && !check_imports) {
       return(lints)
     }
-
-    ## Case 2/3/4: problems with foo in pkg::foo / pkg:::foo
-
-    # run here, not in the factory, to allow for run- vs. "compile"-time differences in package structure
-    namespaces <- lapply(packages, \(package) tryCatch(getNamespace(package), error = identity))
-    failed_namespace <- vapply(namespaces, inherits, "condition", FUN.VALUE = logical(1L))
-
-    # nocov start
-    if (any(failed_namespace)) {
-      cli_abort_internal("Failed to retrieve namespaces for one or more of the packages used with `::` or `:::`. ")
-    }
-    # nocov end
 
     ns_get <- xml_text(ns_nodes) == "::"
     symbol_nodes <- xml_find_all_(ns_nodes, "following-sibling::*[1]")
     symbols <- get_r_string(symbol_nodes)
+    symbols <- gsub("^`(.*)`$", "\\1", symbols)
 
-    if (check_nonexports) {
-      lints <- c(lints, build_ns_get_int_lints(
-        packages[!ns_get],
-        symbols[!ns_get],
-        symbol_nodes[!ns_get],
-        namespaces[!ns_get],
-        source_expression
-      ))
+    if (check_imports) {
+      pkg_path <- find_package(source_expression$filename)
+      ns_imports <- if (!is.null(pkg_path)) namespace_imports(pkg_path) else empty_namespace_data()
+      is_imported <- is_in_imports(packages, symbols, ns_imports)
+      if (any(is_imported)) {
+        lints <- c(lints, build_ns_imports_lints(
+          packages[is_imported],
+          symbols[is_imported],
+          symbol_nodes[is_imported],
+          ns_get[is_imported],
+          source_expression
+        ))
+        packages <- packages[!is_imported]
+        symbols <- symbols[!is_imported]
+        symbol_nodes <- symbol_nodes[!is_imported]
+        ns_nodes <- ns_nodes[!is_imported]
+        ns_get <- ns_get[!is_imported]
+      }
     }
 
-    if (check_exports) {
-      lints <- c(lints, build_ns_get_lints(
-        packages[ns_get],
-        symbols[ns_get],
-        symbol_nodes[ns_get],
-        namespaces[ns_get],
-        source_expression
-      ))
+    if ((check_exports || check_nonexports) && length(packages) > 0L) {
+      ## Case 2/3/4: problems with foo in pkg::foo / pkg:::foo
+
+      # run here, not in the factory, to allow for run- vs. "compile"-time differences in package structure
+      namespaces <- lapply(packages, \(package) tryCatch(getNamespace(package), error = identity))
+      failed_namespace <- vapply(namespaces, inherits, "condition", FUN.VALUE = logical(1L))
+
+      # nocov start
+      if (any(failed_namespace)) {
+        cli_abort_internal("Failed to retrieve namespaces for one or more of the packages used with `::` or `:::`. ")
+      }
+      # nocov end
+
+      if (check_nonexports) {
+        lints <- c(lints, build_ns_get_int_lints(
+          packages[!ns_get],
+          symbols[!ns_get],
+          symbol_nodes[!ns_get],
+          namespaces[!ns_get],
+          source_expression
+        ))
+      }
+
+      if (check_exports) {
+        lints <- c(lints, build_ns_get_lints(
+          packages[ns_get],
+          symbols[ns_get],
+          symbol_nodes[ns_get],
+          namespaces[ns_get],
+          source_expression
+        ))
+      }
     }
 
     lints
@@ -128,6 +158,29 @@ is_in_pkg <- function(symbols, namespaces, exported = TRUE) {
     seq_along(symbols),
     \(ii) symbols[[ii]] %in% namespace_symbols(namespaces[[ii]], exported = exported),
     logical(1L)
+  )
+}
+is_in_imports <- function(packages, symbols, ns_imports) {
+  if (nrow(ns_imports) == 0L) {
+    return(rep(FALSE, length(symbols)))
+  }
+  vapply(
+    seq_along(symbols),
+    \(ii) any(ns_imports$pkg == packages[[ii]] & ns_imports$fun == symbols[[ii]]),
+    logical(1L)
+  )
+}
+
+build_ns_imports_lints <- function(packages, symbols, symbol_nodes, ns_get, source_expression) {
+  ns_get_text <- ifelse(ns_get, "::", ":::")
+  xml_nodes_to_lints(
+    symbol_nodes,
+    source_expression = source_expression,
+    lint_message = sprintf(
+      "Don't use `%s` to access %s, which is already imported from %s.",
+      ns_get_text, symbols, packages
+    ),
+    type = "warning"
   )
 }
 
@@ -160,9 +213,6 @@ build_ns_get_int_lints <- function(packages, symbols, symbol_nodes, namespaces, 
 }
 
 build_ns_get_lints <- function(packages, symbols, symbol_nodes, namespaces, source_expression) {
-  # strip backticked symbols; `%>%` is the same as %>% (#1752).
-  symbols <- gsub("^`(.*)`$", "\\1", symbols)
-
   ## Case 4: foo is not an export in pkg::foo
   unexported <- !is_in_pkg(symbols, namespaces)
   xml_nodes_to_lints(

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -117,12 +117,14 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
     ns_imports <- if (!is.null(pkg_path)) namespace_imports(pkg_path) else empty_namespace_data()
     is_imported <- is_in_imports(packages, symbols, ns_imports)
     if (any(is_imported)) {
-      lints <- c(lints, build_ns_imports_lints(
-        packages[is_imported],
-        symbols[is_imported],
+      lints <- c(lints, xml_nodes_to_lints(
         symbol_nodes[is_imported],
-        ns_get[is_imported],
-        source_expression
+        source_expression = source_expression,
+        lint_message = sprintf(
+          "Don't use `%s` to access %s, which is already imported from %s.",
+          ifelse(ns_get[is_imported], "::", ":::"), symbols[is_imported], packages[is_imported]
+        ),
+        type = "warning"
       ))
       packages <- packages[!is_imported]
       symbols <- symbols[!is_imported]
@@ -157,19 +159,6 @@ is_in_imports <- function(packages, symbols, ns_imports) {
     seq_along(symbols),
     \(ii) any(ns_imports$pkg == packages[[ii]] & ns_imports$fun == symbols[[ii]]),
     logical(1L)
-  )
-}
-
-build_ns_imports_lints <- function(packages, symbols, symbol_nodes, ns_get, source_expression) {
-  ns_get_text <- ifelse(ns_get, "::", ":::")
-  xml_nodes_to_lints(
-    symbol_nodes,
-    source_expression = source_expression,
-    lint_message = sprintf(
-      "Don't use `%s` to access %s, which is already imported from %s.",
-      ns_get_text, symbols, packages
-    ),
-    type = "warning"
   )
 }
 

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -114,7 +114,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
     }
 
     pkg_path <- find_package(source_expression$filename)
-    ns_imports <- if (!is.null(pkg_path)) namespace_imports(pkg_path) else empty_namespace_data()
+    ns_imports <- namespace_imports(pkg_path)
     is_imported <- is_in_imports(packages, symbols, ns_imports)
     if (any(is_imported)) {
       lints <- c(lints, xml_nodes_to_lints(

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -131,40 +131,6 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
       ns_get <- ns_get[!is_imported]
     }
 
-    if ((check_exports || check_nonexports) && length(packages) > 0L) {
-      ## Case 2/3/4: problems with foo in pkg::foo / pkg:::foo
-
-      # run here, not in the factory, to allow for run- vs. "compile"-time differences in package structure
-      namespaces <- lapply(packages, \(package) tryCatch(getNamespace(package), packageNotFoundError = identity))
-      failed_namespace <- vapply(namespaces, inherits, "packageNotFoundError", FUN.VALUE = logical(1L))
-
-      # nocov start
-      if (any(failed_namespace)) {
-        cli_abort_internal("Failed to retrieve namespaces for one or more of the packages used with `::` or `:::`. ")
-      }
-      # nocov end
-
-      if (check_nonexports) {
-        lints <- c(lints, build_ns_get_int_lints(
-          packages[!ns_get],
-          symbols[!ns_get],
-          symbol_nodes[!ns_get],
-          namespaces[!ns_get],
-          source_expression
-        ))
-      }
-
-      if (check_exports) {
-        lints <- c(lints, build_ns_get_lints(
-          packages[ns_get],
-          symbols[ns_get],
-          symbol_nodes[ns_get],
-          namespaces[ns_get],
-          source_expression
-        ))
-      }
-    }
-
     lints
   })
 }

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -91,7 +91,7 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
     ns_get <- xml_text(ns_nodes) == "::"
     symbol_nodes <- xml_find_all_(ns_nodes, "following-sibling::*[1]")
     symbols <- get_r_string(symbol_nodes)
-    symbols <- gsub("^`(.*)`$", "\\1", symbols)
+    symbols <- sub("^`(.*)`$", "\\1", symbols)
 
     if (check_nonexports) {
       lints <- c(lints, build_ns_get_int_lints(

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -151,7 +151,7 @@ is_in_pkg <- function(symbols, namespaces, exported = TRUE) {
 }
 is_in_imports <- function(packages, symbols, ns_imports) {
   if (nrow(ns_imports) == 0L) {
-    return(rep(FALSE, length(symbols)))
+    return(FALSE)
   }
   vapply(
     seq_along(symbols),

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -6,8 +6,6 @@
 #'
 #' @param check_exports Check if `symbol` is exported from `namespace` in `namespace::symbol` calls.
 #' @param check_nonexports Check if `symbol` exists in `namespace` in `namespace:::symbol` calls.
-#' @param check_imports Check if `symbol` is already imported from `namespace` in `namespace::symbol` or
-#'   `namespace:::symbol` calls.
 #'
 #' @examples
 #' # will produce lints
@@ -37,15 +35,10 @@
 #'   linters = namespace_linter(check_nonexports = FALSE)
 #' )
 #'
-#' lint(
-#'   text = "stats::sd(c(1, 2, 3))",
-#'   linters = namespace_linter(check_imports = FALSE)
-#' )
-#'
 #' @evalRd rd_tags("namespace_linter")
 #' @seealso [linters] for a complete list of linters available in lintr.
 #' @export
-namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE, check_imports = TRUE) {
+namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
   Linter(linter_level = "file", function(source_expression) {
     xml <- source_expression$full_xml_parsed_content
 
@@ -79,33 +72,27 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE, chec
       package_nodes <- package_nodes[installed]
     }
 
-    if (!check_exports && !check_nonexports && !check_imports) {
-      return(lints)
-    }
-
     ns_get <- xml_text(ns_nodes) == "::"
     symbol_nodes <- xml_find_all_(ns_nodes, "following-sibling::*[1]")
     symbols <- get_r_string(symbol_nodes)
     symbols <- gsub("^`(.*)`$", "\\1", symbols)
 
-    if (check_imports) {
-      pkg_path <- find_package(source_expression$filename)
-      ns_imports <- if (!is.null(pkg_path)) namespace_imports(pkg_path) else empty_namespace_data()
-      is_imported <- is_in_imports(packages, symbols, ns_imports)
-      if (any(is_imported)) {
-        lints <- c(lints, build_ns_imports_lints(
-          packages[is_imported],
-          symbols[is_imported],
-          symbol_nodes[is_imported],
-          ns_get[is_imported],
-          source_expression
-        ))
-        packages <- packages[!is_imported]
-        symbols <- symbols[!is_imported]
-        symbol_nodes <- symbol_nodes[!is_imported]
-        ns_nodes <- ns_nodes[!is_imported]
-        ns_get <- ns_get[!is_imported]
-      }
+    pkg_path <- find_package(source_expression$filename)
+    ns_imports <- if (!is.null(pkg_path)) namespace_imports(pkg_path) else empty_namespace_data()
+    is_imported <- is_in_imports(packages, symbols, ns_imports)
+    if (any(is_imported)) {
+      lints <- c(lints, build_ns_imports_lints(
+        packages[is_imported],
+        symbols[is_imported],
+        symbol_nodes[is_imported],
+        ns_get[is_imported],
+        source_expression
+      ))
+      packages <- packages[!is_imported]
+      symbols <- symbols[!is_imported]
+      symbol_nodes <- symbol_nodes[!is_imported]
+      ns_nodes <- ns_nodes[!is_imported]
+      ns_get <- ns_get[!is_imported]
     }
 
     if ((check_exports || check_nonexports) && length(packages) > 0L) {

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -115,7 +115,15 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
 
     pkg_path <- find_package(source_expression$filename)
     ns_imports <- namespace_imports(pkg_path)
-    is_imported <- is_in_imports(packages, symbols, ns_imports)
+    if (nrow(ns_imports) == 0L) {
+      return(lints)
+    }
+
+    is_imported <- vapply(
+      seq_along(symbols),
+      \(ii) any(ns_imports$pkg == packages[ii] & ns_imports$fun == symbols[ii]),
+      logical(1L)
+    )
     if (any(is_imported)) {
       lints <- c(lints, xml_nodes_to_lints(
         symbol_nodes[is_imported],
@@ -143,16 +151,6 @@ is_in_pkg <- function(symbols, namespaces, exported = TRUE) {
   vapply(
     seq_along(symbols),
     \(ii) symbols[[ii]] %in% namespace_symbols(namespaces[[ii]], exported = exported),
-    logical(1L)
-  )
-}
-is_in_imports <- function(packages, symbols, ns_imports) {
-  if (nrow(ns_imports) == 0L) {
-    return(FALSE)
-  }
-  vapply(
-    seq_along(symbols),
-    \(ii) any(ns_imports$pkg == packages[[ii]] & ns_imports$fun == symbols[[ii]]),
     logical(1L)
   )
 }

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -72,10 +72,46 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
       package_nodes <- package_nodes[installed]
     }
 
+    if (length(packages) == 0L) {
+      return(lints)
+    }
+
+    ## Case 2/3/4/5: problems with foo in pkg::foo / pkg:::foo
+
+    # run here, not in the factory, to allow for run- vs. "compile"-time differences in package structure
+    namespaces <- lapply(packages, \(package) tryCatch(getNamespace(package), packageNotFoundError = identity))
+    failed_namespace <- vapply(namespaces, inherits, "packageNotFoundError", FUN.VALUE = logical(1L))
+
+    # nocov start
+    if (any(failed_namespace)) {
+      cli_abort_internal("Failed to retrieve namespaces for one or more of the packages used with `::` or `:::`. ")
+    }
+    # nocov end
+
     ns_get <- xml_text(ns_nodes) == "::"
     symbol_nodes <- xml_find_all_(ns_nodes, "following-sibling::*[1]")
     symbols <- get_r_string(symbol_nodes)
     symbols <- gsub("^`(.*)`$", "\\1", symbols)
+
+    if (check_nonexports) {
+      lints <- c(lints, build_ns_get_int_lints(
+        packages[!ns_get],
+        symbols[!ns_get],
+        symbol_nodes[!ns_get],
+        namespaces[!ns_get],
+        source_expression
+      ))
+    }
+
+    if (check_exports) {
+      lints <- c(lints, build_ns_get_lints(
+        packages[ns_get],
+        symbols[ns_get],
+        symbol_nodes[ns_get],
+        namespaces[ns_get],
+        source_expression
+      ))
+    }
 
     pkg_path <- find_package(source_expression$filename)
     ns_imports <- if (!is.null(pkg_path)) namespace_imports(pkg_path) else empty_namespace_data()
@@ -99,8 +135,8 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
       ## Case 2/3/4: problems with foo in pkg::foo / pkg:::foo
 
       # run here, not in the factory, to allow for run- vs. "compile"-time differences in package structure
-      namespaces <- lapply(packages, \(package) tryCatch(getNamespace(package), error = identity))
-      failed_namespace <- vapply(namespaces, inherits, "condition", FUN.VALUE = logical(1L))
+      namespaces <- lapply(packages, \(package) tryCatch(getNamespace(package), packageNotFoundError = identity))
+      failed_namespace <- vapply(namespaces, inherits, "packageNotFoundError", FUN.VALUE = logical(1L))
 
       # nocov start
       if (any(failed_namespace)) {

--- a/R/namespace_linter.R
+++ b/R/namespace_linter.R
@@ -126,11 +126,6 @@ namespace_linter <- function(check_exports = TRUE, check_nonexports = TRUE) {
         ),
         type = "warning"
       ))
-      packages <- packages[!is_imported]
-      symbols <- symbols[!is_imported]
-      symbol_nodes <- symbol_nodes[!is_imported]
-      ns_nodes <- ns_nodes[!is_imported]
-      ns_get <- ns_get[!is_imported]
     }
 
     lints

--- a/R/paste_linter.R
+++ b/R/paste_linter.R
@@ -180,7 +180,7 @@ paste_linter <- function(allow_empty_sep = FALSE,
   empty_paste_note <-
     'Note that paste() converts empty inputs to "", whereas file.path() leaves it empty.'
 
-  paste0_collapse_xpath <- glue::glue("
+  paste0_collapse_xpath <- glue("
   parent::expr[
     SYMBOL_SUB[text() = 'collapse']
     and count(expr) =

--- a/R/use_lintr.R
+++ b/R/use_lintr.R
@@ -51,7 +51,7 @@ use_lintr <- function(path = ".", type = c("tidyverse", "full")) {
 
   rbuildignore_path <- file.path(pkg_path, ".Rbuildignore")
   rel_path <- xfun::relative_path(config_file, pkg_path)
-  escaped_config_path <- rex::rex(start, rel_path, end)
+  escaped_config_path <- rex(start, rel_path, end)
 
   if (!file.exists(rbuildignore_path)) {
     writeLines(escaped_config_path, rbuildignore_path)

--- a/R/xp_utils.R
+++ b/R/xp_utils.R
@@ -124,7 +124,7 @@ xpath_comment_re <- rex(
   zero_or_more(not(":)")),
   ":)"
 )
-xp_strip_comments <- function(xpath) rex::re_substitutes(xpath, xpath_comment_re, "", global = TRUE)
+xp_strip_comments <- function(xpath) re_substitutes(xpath, xpath_comment_re, "", global = TRUE)
 
 #' Combine two or more nodesets to a single nodeset
 #'

--- a/man/namespace_linter.Rd
+++ b/man/namespace_linter.Rd
@@ -4,19 +4,12 @@
 \alias{namespace_linter}
 \title{Namespace linter}
 \usage{
-namespace_linter(
-  check_exports = TRUE,
-  check_nonexports = TRUE,
-  check_imports = TRUE
-)
+namespace_linter(check_exports = TRUE, check_nonexports = TRUE)
 }
 \arguments{
 \item{check_exports}{Check if \code{symbol} is exported from \code{namespace} in \code{namespace::symbol} calls.}
 
 \item{check_nonexports}{Check if \code{symbol} exists in \code{namespace} in \code{namespace:::symbol} calls.}
-
-\item{check_imports}{Check if \code{symbol} is already imported from \code{namespace} in \code{namespace::symbol} or
-\code{namespace:::symbol} calls.}
 }
 \description{
 Check for missing packages and symbols in namespace calls.
@@ -49,11 +42,6 @@ lint(
 lint(
   text = "stats:::ssd(c(1, 2, 3))",
   linters = namespace_linter(check_nonexports = FALSE)
-)
-
-lint(
-  text = "stats::sd(c(1, 2, 3))",
-  linters = namespace_linter(check_imports = FALSE)
 )
 
 }

--- a/man/namespace_linter.Rd
+++ b/man/namespace_linter.Rd
@@ -4,12 +4,19 @@
 \alias{namespace_linter}
 \title{Namespace linter}
 \usage{
-namespace_linter(check_exports = TRUE, check_nonexports = TRUE)
+namespace_linter(
+  check_exports = TRUE,
+  check_nonexports = TRUE,
+  check_imports = TRUE
+)
 }
 \arguments{
 \item{check_exports}{Check if \code{symbol} is exported from \code{namespace} in \code{namespace::symbol} calls.}
 
 \item{check_nonexports}{Check if \code{symbol} exists in \code{namespace} in \code{namespace:::symbol} calls.}
+
+\item{check_imports}{Check if \code{symbol} is already imported from \code{namespace} in \code{namespace::symbol} or
+\code{namespace:::symbol} calls.}
 }
 \description{
 Check for missing packages and symbols in namespace calls.
@@ -42,6 +49,11 @@ lint(
 lint(
   text = "stats:::ssd(c(1, 2, 3))",
   linters = namespace_linter(check_nonexports = FALSE)
+)
+
+lint(
+  text = "stats::sd(c(1, 2, 3))",
+  linters = namespace_linter(check_imports = FALSE)
 )
 
 }

--- a/tests/testthat/test-namespace_linter.R
+++ b/tests/testthat/test-namespace_linter.R
@@ -131,18 +131,18 @@ test_that("namespace_linter works with backticked symbols", {
 
   pkg_dir <- withr::local_tempdir("testpkg_rlang")
   dir.create(file.path(pkg_dir, "R"))
-  writeLines("Package: testpkg_rlang\nVersion: 1.0.0\n", file.path(pkg_dir, "DESCRIPTION"))
-  writeLines('importFrom("rlang", "%||%")\n', file.path(pkg_dir, "NAMESPACE"))
-
-  linter <- namespace_linter()
+  write.dcf(
+    list(Package = "testpkg_rlang", Version = "1.0.0"),
+    file.path(pkg_dir, "DESCRIPTION")
+  )
+  writeLines('importFrom("rlang", "%||%")', file.path(pkg_dir, "NAMESPACE"))
 
   test_file <- file.path(pkg_dir, "R", "test.R")
-  writeLines("rlang::`%||%`\n", test_file)
+  writeLines("rlang::`%||%`", test_file)
 
   expect_lint(
-    content = "",
     file = test_file,
-    rex::rex("Don't use `::` to access %||%, which is already imported from rlang."),
-    linter
+    checks = rex::rex("Don't use `::` to access %||%, which is already imported from rlang."),
+    linters = namespace_linter()
   )
 })

--- a/tests/testthat/test-namespace_linter.R
+++ b/tests/testthat/test-namespace_linter.R
@@ -121,17 +121,9 @@ test_that("namespace_linter detects functions already imported in the NAMESPACE"
     ),
     linter
   )
-
-  test_file2 <- file.path(pkg_dir, "R", "test2.R")
-  writeLines("stats::median(1:10)\n", test_file2)
-  expect_no_lint(
-    content = "",
-    file = test_file2,
-    namespace_linter(check_imports = FALSE)
-  )
 })
 
-test_that("namespace_linter check_imports works with backticked symbols", {
+test_that("namespace_linter works with backticked symbols", {
   skip_if_not_installed("rlang")
 
   pkg_dir <- withr::local_tempdir("testpkg_rlang")

--- a/tests/testthat/test-namespace_linter.R
+++ b/tests/testthat/test-namespace_linter.R
@@ -93,3 +93,61 @@ test_that("lints vectorize", {
     namespace_linter()
   )
 })
+
+test_that("namespace_linter detects functions already imported in the NAMESPACE", {
+  pkg_dir <- withr::local_tempdir("testpkg")
+  dir.create(file.path(pkg_dir, "R"))
+  writeLines("Package: testpkg\nVersion: 1.0.0\n", file.path(pkg_dir, "DESCRIPTION"))
+  writeLines("importFrom(stats, median)\nimportFrom(utils, head)\n", file.path(pkg_dir, "NAMESPACE"))
+
+  linter <- namespace_linter()
+
+  test_file <- file.path(pkg_dir, "R", "test.R")
+  writeLines(
+    trim_some("
+      stats::median(1:10)
+      utils:::head(1:10)
+      stats::sd(1:10)
+    "),
+    test_file
+  )
+
+  expect_lint(
+    content = "",
+    file = test_file,
+    list(
+      list(rex::rex("Don't use `::` to access median, which is already imported from stats."), line_number = 1L),
+      list(rex::rex("Don't use `:::` to access head, which is already imported from utils."), line_number = 2L)
+    ),
+    linter
+  )
+
+  test_file2 <- file.path(pkg_dir, "R", "test2.R")
+  writeLines("stats::median(1:10)\n", test_file2)
+  expect_no_lint(
+    content = "",
+    file = test_file2,
+    namespace_linter(check_imports = FALSE)
+  )
+})
+
+test_that("namespace_linter check_imports works with backticked symbols", {
+  skip_if_not_installed("rlang")
+
+  pkg_dir <- withr::local_tempdir("testpkg_rlang")
+  dir.create(file.path(pkg_dir, "R"))
+  writeLines("Package: testpkg_rlang\nVersion: 1.0.0\n", file.path(pkg_dir, "DESCRIPTION"))
+  writeLines('importFrom("rlang", "%||%")\n', file.path(pkg_dir, "NAMESPACE"))
+
+  linter <- namespace_linter()
+
+  test_file <- file.path(pkg_dir, "R", "test.R")
+  writeLines("rlang::`%||%`\n", test_file)
+
+  expect_lint(
+    content = "",
+    file = test_file,
+    rex::rex("Don't use `::` to access %||%, which is already imported from rlang."),
+    linter
+  )
+})

--- a/tests/testthat/test-namespace_linter.R
+++ b/tests/testthat/test-namespace_linter.R
@@ -97,29 +97,32 @@ test_that("lints vectorize", {
 test_that("namespace_linter detects functions already imported in the NAMESPACE", {
   pkg_dir <- withr::local_tempdir("testpkg")
   dir.create(file.path(pkg_dir, "R"))
-  writeLines("Package: testpkg\nVersion: 1.0.0\n", file.path(pkg_dir, "DESCRIPTION"))
-  writeLines("importFrom(stats, median)\nimportFrom(utils, head)\n", file.path(pkg_dir, "NAMESPACE"))
-
-  linter <- namespace_linter()
+  write.dcf(
+    list(Package = "testpkg", Version = "1.0.0"),
+    file.path(pkg_dir, "DESCRIPTION")
+  )
+  writeLines(
+    c("importFrom(stats, median)", "importFrom(utils, head)"),
+    file.path(pkg_dir, "NAMESPACE")
+  )
 
   test_file <- file.path(pkg_dir, "R", "test.R")
   writeLines(
-    trim_some("
-      stats::median(1:10)
-      utils:::head(1:10)
-      stats::sd(1:10)
-    "),
+    c(
+      "stats::median(1:10)",
+      "utils:::head(1:10)",
+      "stats::sd(1:10) # not imported"
+    ),
     test_file
   )
 
   expect_lint(
-    content = "",
     file = test_file,
-    list(
-      list(rex::rex("Don't use `::` to access median, which is already imported from stats."), line_number = 1L),
-      list(rex::rex("Don't use `:::` to access head, which is already imported from utils."), line_number = 2L)
+    checks = list(
+      list("Don't use `::` to access median.*already imported", line_number = 1L),
+      list("Don't use `:::` to access head.*already imported", line_number = 2L)
     ),
-    linter
+    linters = namespace_linter(check_nonexports = FALSE)
   )
 })
 

--- a/tests/testthat/test-namespace_linter.R
+++ b/tests/testthat/test-namespace_linter.R
@@ -94,7 +94,7 @@ test_that("lints vectorize", {
   )
 })
 
-test_that("namespace_linter detects functions already imported in the NAMESPACE", {
+test_that("namespace_linter detects functions already imported in the NAMESPACE", { # nofuzz
   pkg_dir <- withr::local_tempdir("testpkg")
   dir.create(file.path(pkg_dir, "R"))
   write.dcf(
@@ -126,7 +126,7 @@ test_that("namespace_linter detects functions already imported in the NAMESPACE"
   )
 })
 
-test_that("namespace_linter works with backticked symbols", {
+test_that("namespace_linter works with backticked symbols", { # nofuzz
   skip_if_not_installed("rlang")
 
   pkg_dir <- withr::local_tempdir("testpkg_rlang")


### PR DESCRIPTION
Closes #2081. It already found some hits on {lintr} itself!