### PR TITLE
Require unreachable expression parent to be '{'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # lintr (in development)
 
+### Lint accuracy fixes: removing false positives
+
+* `unreachable_code_linter()` no longer flags cases like `switch(x, a = stop("invalid value"))` where `stop()` is in a nested call (#3084, @MichaelChirico).
+
 # lintr (3.4.0)
 
 ## Deprecations & breaking changes

--- a/R/unreachable_code_linter.R
+++ b/R/unreachable_code_linter.R
@@ -83,11 +83,11 @@ unreachable_code_linter <- function(allow_comment_regex = getOption("covr.exclud
 
   # normal case: expression after terminal call is on the next line
   unreachable_expr_cond_ws <- "
-  self::*[parent::expr[OP-LEFT-BRACE]]
-    /following-sibling::*[
-      not(self::OP-RIGHT-BRACE or self::OP-SEMICOLON or self::ELSE or preceding-sibling::ELSE)
-      and (not(self::COMMENT) or @line2 > preceding-sibling::*[not(self::COMMENT)][1]/@line2)
-    ][1]"
+  following-sibling::*[
+    parent::expr/OP-LEFT-BRACE
+    and not(self::OP-RIGHT-BRACE or self::OP-SEMICOLON or self::ELSE or preceding-sibling::ELSE)
+    and (not(self::COMMENT) or @line2 > preceding-sibling::*[not(self::COMMENT)][1]/@line2)
+  ][1]"
   # robustness case: expression after terminal call is on the same line (after a semicolon),
   #   wherefore the condition is a bit different due to <exprlist> nodes
   unreachable_expr_cond_sc <- "

--- a/R/unreachable_code_linter.R
+++ b/R/unreachable_code_linter.R
@@ -83,10 +83,11 @@ unreachable_code_linter <- function(allow_comment_regex = getOption("covr.exclud
 
   # normal case: expression after terminal call is on the next line
   unreachable_expr_cond_ws <- "
-  following-sibling::*[
-    not(self::OP-RIGHT-BRACE or self::OP-SEMICOLON or self::ELSE or preceding-sibling::ELSE)
-    and (not(self::COMMENT) or @line2 > preceding-sibling::*[not(self::COMMENT)][1]/@line2)
-  ][1]"
+  self::*[parent::expr[OP-LEFT-BRACE]]
+    /following-sibling::*[
+      not(self::OP-RIGHT-BRACE or self::OP-SEMICOLON or self::ELSE or preceding-sibling::ELSE)
+      and (not(self::COMMENT) or @line2 > preceding-sibling::*[not(self::COMMENT)][1]/@line2)
+    ][1]"
   # robustness case: expression after terminal call is on the same line (after a semicolon),
   #   wherefore the condition is a bit different due to <exprlist> nodes
   unreachable_expr_cond_sc <- "

--- a/tests/testthat/test-unreachable_code_linter.R
+++ b/tests/testthat/test-unreachable_code_linter.R
@@ -821,6 +821,18 @@ test_that("unreachable_code_linter does not trigger inside function calls like s
     linter
   )
 
+  expect_no_lint(
+    trim_some('
+      repeat {
+        switch(x,
+          a = break,
+          b = "d"
+        )
+      }
+    '),
+    linter
+  )
+
   expect_lint(
     trim_some("
       foo <- function(x) {

--- a/tests/testthat/test-unreachable_code_linter.R
+++ b/tests/testthat/test-unreachable_code_linter.R
@@ -795,7 +795,7 @@ test_that("unreachable_code_linter does not trigger inside function calls like s
     trim_some("
       foo <- function(x) {
         y <- switch(x, a = 1, b = 2, stop('bad x'))
-        return(x + y)
+        x + y
       }
     "),
     linter
@@ -805,7 +805,7 @@ test_that("unreachable_code_linter does not trigger inside function calls like s
     trim_some("
       foo <- function(x) {
         y <- switch(x, a = stop('bad x'), b = 2)
-        return(x + y)
+        x + y
       }
     "),
     linter
@@ -815,7 +815,7 @@ test_that("unreachable_code_linter does not trigger inside function calls like s
     trim_some("
       foo <- function(x) {
         y <- ifelse(x > 0, x, stop('negative x'))
-        return(y)
+        y
       }
     "),
     linter
@@ -828,7 +828,7 @@ test_that("unreachable_code_linter does not trigger inside function calls like s
           stop('bad x')
           2 + 2
         })
-        return(x + y)
+        x + y
       }
     "),
     rex::rex("Remove code and comments coming after stop()."),

--- a/tests/testthat/test-unreachable_code_linter.R
+++ b/tests/testthat/test-unreachable_code_linter.R
@@ -787,3 +787,51 @@ test_that("allow_comment_regex= obeys covr's custom exclusion when set", {
     linter_covr
   )
 })
+
+test_that("unreachable_code_linter does not trigger inside function calls like switch", {
+  linter <- unreachable_code_linter()
+
+  expect_no_lint(
+    trim_some("
+      foo <- function(x) {
+        y <- switch(x, a = 1, b = 2, stop('bad x'))
+        return(x + y)
+      }
+    "),
+    linter
+  )
+
+  expect_no_lint(
+    trim_some("
+      foo <- function(x) {
+        y <- switch(x, a = stop('bad x'), b = 2)
+        return(x + y)
+      }
+    "),
+    linter
+  )
+
+  expect_no_lint(
+    trim_some("
+      foo <- function(x) {
+        y <- ifelse(x > 0, x, stop('negative x'))
+        return(y)
+      }
+    "),
+    linter
+  )
+
+  expect_lint(
+    trim_some("
+      foo <- function(x) {
+        y <- switch(x, a = {
+          stop('bad x')
+          2 + 2
+        })
+        return(x + y)
+      }
+    "),
+    rex::rex("Remove code and comments coming after stop()."),
+    linter
+  )
+})


### PR DESCRIPTION
Closes #3084, closes #3023